### PR TITLE
[PBXProj] Avoid checking if starting objects section unless at top-level

### DIFF
--- a/lib/nanaimo/writer/pbxproj.rb
+++ b/lib/nanaimo/writer/pbxproj.rb
@@ -40,7 +40,11 @@ module Nanaimo
       end
 
       def write_dictionary_key_value_pair(k, v)
-        @objects_section = true if value_for(k) == 'objects'
+        # since the objects section is always at the top-level,
+        # we can avoid checking if we're starting the 'objects'
+        # section if we're further "indented" (aka deeper) in the project
+        @objects_section = true if indent == 1 && value_for(k) == 'objects'
+
         super
       end
 


### PR DESCRIPTION
Need to check what performance impact this has on a half million object project file when I get back to the office