### PR TITLE
Speed up PBXProj#sort_dictionary

### DIFF
--- a/lib/nanaimo/writer/pbxproj.rb
+++ b/lib/nanaimo/writer/pbxproj.rb
@@ -28,7 +28,7 @@ module Nanaimo
           write_newline
           output << "/* Begin #{isa} section */"
           write_newline
-          sort_dictionary(kvs).each do |k, v|
+          sort_dictionary(kvs, key_can_be_isa: false).each do |k, v|
             write_dictionary_key_value_pair(k, v)
           end
           output << "/* End #{isa} section */"
@@ -44,19 +44,15 @@ module Nanaimo
         super
       end
 
-      def sort_dictionary(dictionary)
+      def sort_dictionary(dictionary, key_can_be_isa: true)
         hash = value_for(dictionary)
-        hash.to_a.sort do |(k1, v1), (k2, v2)|
-          v2_isa = isa_for(v2)
-          v1_isa = v2_isa && isa_for(v1)
-          comp = v1_isa <=> v2_isa
-          next comp if !comp.zero? && v1_isa
-
-          key1 = value_for(k1)
-          key2 = value_for(k2)
-          next -1 if key1 == 'isa'
-          next 1 if key2 == 'isa'
-          key1 <=> key2
+        hash.sort_by do |k, _v|
+          k = value_for(k)
+          if key_can_be_isa
+            k == 'isa' ? '' : k
+          else
+            k
+          end
         end
       end
 


### PR DESCRIPTION
Using #sort_by cuts down on the number of calls to #value_for, as well as the number of String#==

Eliminates checking if the key is isa for all of the objects in the project

Avoids comparing value isas, since we already group (& sort) by them in the objects section