### PR TITLE
Ruby 2.7.0 support remove all warnings during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+bundler_args: --without debugging documentation
 branches:
   only:
     - master
@@ -6,7 +8,11 @@ language: ruby
 cache: bundler
 rvm:
   # The latest ruby version
+  - 2.7.0
+  - 2.6.2
   - 2.5.0
   - 2.4.2
   # OS X 10.9.5-10.10.0 (2.0.0-p481)
   - 2.0.0-p481
+before_install:
+  - gem install bundler -v "~> 1.17"

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
+  gem 'rake', '~> 12.0'
+  gem 'rspec'
   gem 'rubocop', install_if: RUBY_VERSION >= '2.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,19 +14,19 @@ GEM
     powerpack (0.1.1)
     rainbow (3.0.0)
     rake (12.3.3)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
     rubocop (0.52.1)
       parallel (~> 1.10)
       parser (>= 2.4.0.2, < 3.0)
@@ -43,9 +43,9 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.12)
   nanaimo!
-  rake (~> 12.3)
-  rspec (~> 3.0)
+  rake (~> 12.0)
+  rspec
   rubocop
 
 BUNDLED WITH
-   1.16.2
+   1.17.3


### PR DESCRIPTION
Also add CI for Ruby 2.7.0.