### PR TITLE
writer: wrap with quotes objects that start with three underscores.

### DIFF
--- a/lib/nanaimo/writer.rb
+++ b/lib/nanaimo/writer.rb
@@ -90,7 +90,7 @@ module Nanaimo
       output
     end
 
-    QUOTED_STRING_REGEXP = %r{\A\z|[^\w\./]}
+    QUOTED_STRING_REGEXP = %r{\A\z|[^\w\./]|\A___}
     private_constant :QUOTED_STRING_REGEXP
 
     def write_string_quoted_if_necessary(object)

--- a/spec/fixtures/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/spec/fixtures/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -1,0 +1,2511 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0353A1CE1E81623B00067996 /* any.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA43F1E7AE4AC004F6E95 /* any.pb.swift */; };
+		0353A1CF1E81624F00067996 /* any.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA43F1E7AE4AC004F6E95 /* any.pb.swift */; };
+		0353A1D01E81625400067996 /* any.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA43F1E7AE4AC004F6E95 /* any.pb.swift */; };
+		8DC1CA0D1E54B80800CA8A26 /* MathUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC1CA0C1E54B80800CA8A26 /* MathUtils.swift */; };
+		8DC1CA0F1E54B81400CA8A26 /* TimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC1CA0E1E54B81400CA8A26 /* TimeUtils.swift */; };
+		9C0B366B1E5FAB910094E128 /* JSONMapEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0B366A1E5FAB910094E128 /* JSONMapEncodingVisitor.swift */; };
+		9C0B366C1E5FAB910094E128 /* JSONMapEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0B366A1E5FAB910094E128 /* JSONMapEncodingVisitor.swift */; };
+		9C0B366D1E5FAB910094E128 /* JSONMapEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0B366A1E5FAB910094E128 /* JSONMapEncodingVisitor.swift */; };
+		9C0B366E1E5FAB910094E128 /* JSONMapEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0B366A1E5FAB910094E128 /* JSONMapEncodingVisitor.swift */; };
+		9C2F237B1D7780D1008524F2 /* api.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/api.pb.swift /* api.pb.swift */; };
+		9C2F237C1D7780D1008524F2 /* duration.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/duration.pb.swift /* duration.pb.swift */; };
+		9C2F237D1D7780D1008524F2 /* empty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/empty.pb.swift /* empty.pb.swift */; };
+		9C2F237E1D7780D1008524F2 /* field_mask.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/field_mask.pb.swift /* field_mask.pb.swift */; };
+		9C2F23801D7780D1008524F2 /* Google_Protobuf_Duration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration+Extensions.swift */; };
+		9C2F23811D7780D1008524F2 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_FieldMask_Extensions.swift /* Google_Protobuf_FieldMask+Extensions.swift */; };
+		9C2F23821D7780D1008524F2 /* Google_Protobuf_Struct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct+Extensions.swift */; };
+		9C2F23831D7780D1008524F2 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Timestamp_Extensions.swift /* Google_Protobuf_Timestamp+Extensions.swift */; };
+		9C2F23851D7780D1008524F2 /* BinaryDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* BinaryDecoder.swift */; };
+		9C2F23861D7780D1008524F2 /* BinaryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift */; };
+		9C2F23871D7780D1008524F2 /* Message+BinaryAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* Message+BinaryAdditions.swift */; };
+		9C2F23891D7780D1008524F2 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */; };
+		9C2F238B1D7780D1008524F2 /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */; };
+		9C2F238C1D7780D1008524F2 /* MessageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift */; };
+		9C2F238D1D7780D1008524F2 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */; };
+		9C2F238F1D7780D1008524F2 /* HashVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufHash.swift /* HashVisitor.swift */; };
+		9C2F23911D7780D1008524F2 /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufJSONEncoding.swift /* JSONEncoder.swift */; };
+		9C2F23921D7780D1008524F2 /* Message+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufJSONTypes.swift /* Message+JSONAdditions.swift */; };
+		9C2F23931D7780D1008524F2 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufMessage.swift /* Message.swift */; };
+		9C2F23981D7780D1008524F2 /* FieldTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufTypes.swift /* FieldTypes.swift */; };
+		9C2F23991D7780D1008524F2 /* UnknownStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufUnknown.swift /* UnknownStorage.swift */; };
+		9C2F239B1D7780D1008524F2 /* source_context.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */; };
+		9C2F239C1D7780D1008524F2 /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */; };
+		9C2F239D1D7780D1008524F2 /* type.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */; };
+		9C4178611E809DA2007830C3 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4178601E809DA2007830C3 /* ExtensionMap.swift */; };
+		9C4178621E809DA2007830C3 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4178601E809DA2007830C3 /* ExtensionMap.swift */; };
+		9C4178631E809DA2007830C3 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4178601E809DA2007830C3 /* ExtensionMap.swift */; };
+		9C4178641E809DA2007830C3 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4178601E809DA2007830C3 /* ExtensionMap.swift */; };
+		9C5890A71DFF5FFC001CFC34 /* Test_TextFormat_proto2_extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5890A51DFF5EC8001CFC34 /* Test_TextFormat_proto2_extensions.swift */; };
+		9C5890A81DFF6375001CFC34 /* TextFormatDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E661DB1210E00957D74 /* TextFormatDecoder.swift */; };
+		9C5890A91DFF6375001CFC34 /* TextFormatEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E671DB1210E00957D74 /* TextFormatEncoder.swift */; };
+		9C5890AA1DFF6375001CFC34 /* TextFormatEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEB0D671DF5E934002D80F0 /* TextFormatEncodingVisitor.swift */; };
+		9C5890AB1DFF6375001CFC34 /* TextFormatScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEB0D6B1DF5F921002D80F0 /* TextFormatScanner.swift */; };
+		9C5890AD1DFF6375001CFC34 /* Message+TextFormatAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E681DB1210E00957D74 /* Message+TextFormatAdditions.swift */; };
+		9C5890AE1DFF6384001CFC34 /* TextFormatDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E661DB1210E00957D74 /* TextFormatDecoder.swift */; };
+		9C5890AF1DFF6384001CFC34 /* TextFormatEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E671DB1210E00957D74 /* TextFormatEncoder.swift */; };
+		9C5890B01DFF6384001CFC34 /* TextFormatEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEB0D671DF5E934002D80F0 /* TextFormatEncodingVisitor.swift */; };
+		9C5890B11DFF6384001CFC34 /* TextFormatScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEB0D6B1DF5F921002D80F0 /* TextFormatScanner.swift */; };
+		9C5890B31DFF6384001CFC34 /* Message+TextFormatAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E681DB1210E00957D74 /* Message+TextFormatAdditions.swift */; };
+		9C5890B41DFF6389001CFC34 /* TextFormatDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E661DB1210E00957D74 /* TextFormatDecoder.swift */; };
+		9C5890B51DFF6389001CFC34 /* TextFormatEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E671DB1210E00957D74 /* TextFormatEncoder.swift */; };
+		9C5890B61DFF6389001CFC34 /* TextFormatEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEB0D671DF5E934002D80F0 /* TextFormatEncodingVisitor.swift */; };
+		9C5890B71DFF6389001CFC34 /* TextFormatScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEB0D6B1DF5F921002D80F0 /* TextFormatScanner.swift */; };
+		9C5890B91DFF6389001CFC34 /* Message+TextFormatAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E681DB1210E00957D74 /* Message+TextFormatAdditions.swift */; };
+		9C60CBE81DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C60CBE71DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift */; };
+		9C60CBE91DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C60CBE71DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift */; };
+		9C60CBEA1DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C60CBE71DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift */; };
+		9C60CBEC1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C60CBEB1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift */; };
+		9C60CBED1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C60CBEB1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift */; };
+		9C60CBEE1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C60CBEB1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift */; };
+		9C667A911E4C203D008B974F /* JSONDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A8E1E4C203D008B974F /* JSONDecodingError.swift */; };
+		9C667A921E4C203D008B974F /* JSONDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A8E1E4C203D008B974F /* JSONDecodingError.swift */; };
+		9C667A931E4C203D008B974F /* JSONDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A8E1E4C203D008B974F /* JSONDecodingError.swift */; };
+		9C667A941E4C203D008B974F /* JSONDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A8E1E4C203D008B974F /* JSONDecodingError.swift */; };
+		9C667A951E4C203D008B974F /* BinaryDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A8F1E4C203D008B974F /* BinaryDecodingError.swift */; };
+		9C667A961E4C203D008B974F /* BinaryDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A8F1E4C203D008B974F /* BinaryDecodingError.swift */; };
+		9C667A971E4C203D008B974F /* BinaryDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A8F1E4C203D008B974F /* BinaryDecodingError.swift */; };
+		9C667A981E4C203D008B974F /* BinaryDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A8F1E4C203D008B974F /* BinaryDecodingError.swift */; };
+		9C667A991E4C203D008B974F /* TextFormatDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A901E4C203D008B974F /* TextFormatDecodingError.swift */; };
+		9C667A9A1E4C203D008B974F /* TextFormatDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A901E4C203D008B974F /* TextFormatDecodingError.swift */; };
+		9C667A9B1E4C203D008B974F /* TextFormatDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A901E4C203D008B974F /* TextFormatDecodingError.swift */; };
+		9C667A9C1E4C203D008B974F /* TextFormatDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A901E4C203D008B974F /* TextFormatDecodingError.swift */; };
+		9C7254661E5F9B1600486C98 /* Test_TextFormat_Unknown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7254651E5F9B1600486C98 /* Test_TextFormat_Unknown.swift */; };
+		9C7254671E5F9B1600486C98 /* Test_TextFormat_Unknown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7254651E5F9B1600486C98 /* Test_TextFormat_Unknown.swift */; };
+		9C7254681E5F9B1600486C98 /* Test_TextFormat_Unknown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7254651E5F9B1600486C98 /* Test_TextFormat_Unknown.swift */; };
+		9C75F8801DDBE0DE005CCFF2 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */; };
+		9C75F8811DDBE0FC005CCFF2 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */; };
+		9C75F8821DDBE10D005CCFF2 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */; };
+		9C75F8831DDBE118005CCFF2 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */; };
+		9C75F8851DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8841DDD3045005CCFF2 /* SimpleExtensionMap.swift */; };
+		9C75F8861DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8841DDD3045005CCFF2 /* SimpleExtensionMap.swift */; };
+		9C75F8871DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8841DDD3045005CCFF2 /* SimpleExtensionMap.swift */; };
+		9C75F8881DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8841DDD3045005CCFF2 /* SimpleExtensionMap.swift */; };
+		9C75F88A1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */; };
+		9C75F88B1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */; };
+		9C75F88C1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */; };
+		9C75F88D1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */; };
+		9C75F88F1DDD3108005CCFF2 /* ExtensibleMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F88E1DDD3108005CCFF2 /* ExtensibleMessage.swift */; };
+		9C75F8901DDD3108005CCFF2 /* ExtensibleMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F88E1DDD3108005CCFF2 /* ExtensibleMessage.swift */; };
+		9C75F8911DDD3108005CCFF2 /* ExtensibleMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F88E1DDD3108005CCFF2 /* ExtensibleMessage.swift */; };
+		9C75F8921DDD3108005CCFF2 /* ExtensibleMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F88E1DDD3108005CCFF2 /* ExtensibleMessage.swift */; };
+		9C75F8941DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8931DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift */; };
+		9C75F8951DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8931DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift */; };
+		9C75F8961DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8931DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift */; };
+		9C75F8971DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8931DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift */; };
+		9C75F89E1DDD3FA3005CCFF2 /* JSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F89D1DDD3FA3005CCFF2 /* JSONDecoder.swift */; };
+		9C75F89F1DDD3FA3005CCFF2 /* JSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F89D1DDD3FA3005CCFF2 /* JSONDecoder.swift */; };
+		9C75F8A01DDD3FA3005CCFF2 /* JSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F89D1DDD3FA3005CCFF2 /* JSONDecoder.swift */; };
+		9C75F8A11DDD3FA3005CCFF2 /* JSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F89D1DDD3FA3005CCFF2 /* JSONDecoder.swift */; };
+		9C75F8A31DDD44A1005CCFF2 /* ProtobufMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8A21DDD44A1005CCFF2 /* ProtobufMap.swift */; };
+		9C75F8A41DDD44A1005CCFF2 /* ProtobufMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8A21DDD44A1005CCFF2 /* ProtobufMap.swift */; };
+		9C75F8A51DDD44A1005CCFF2 /* ProtobufMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8A21DDD44A1005CCFF2 /* ProtobufMap.swift */; };
+		9C75F8A61DDD44A1005CCFF2 /* ProtobufMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8A21DDD44A1005CCFF2 /* ProtobufMap.swift */; };
+		9C84E48F1E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48C1E5E3ABD00513BE0 /* BinaryEncodingError.swift */; };
+		9C84E4901E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48C1E5E3ABD00513BE0 /* BinaryEncodingError.swift */; };
+		9C84E4911E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48C1E5E3ABD00513BE0 /* BinaryEncodingError.swift */; };
+		9C84E4921E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48C1E5E3ABD00513BE0 /* BinaryEncodingError.swift */; };
+		9C84E4931E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48D1E5E3ABD00513BE0 /* JSONEncodingError.swift */; };
+		9C84E4941E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48D1E5E3ABD00513BE0 /* JSONEncodingError.swift */; };
+		9C84E4951E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48D1E5E3ABD00513BE0 /* JSONEncodingError.swift */; };
+		9C84E4961E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48D1E5E3ABD00513BE0 /* JSONEncodingError.swift */; };
+		9C8CDA171D7A288E00E207CA /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Protobuf_iOS" /* SwiftProtobuf.framework */; };
+		9C8CDA1D1D7A28F600E207CA /* any_test.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift */; };
+		9C8CDA1E1D7A28F600E207CA /* conformance.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift */; };
+		9C8CDA201D7A28F600E207CA /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */; };
+		9C8CDA211D7A28F600E207CA /* map_unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */; };
+		9C8CDA231D7A28F600E207CA /* Test_AllTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */; };
+		9C8CDA241D7A28F600E207CA /* Test_AllTypes_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */; };
+		9C8CDA251D7A28F600E207CA /* Test_Any.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */; };
+		9C8CDA261D7A28F600E207CA /* Test_Api.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Api.swift /* Test_Api.swift */; };
+		9C8CDA271D7A28F600E207CA /* Test_Conformance.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Conformance.swift /* Test_Conformance.swift */; };
+		9C8CDA291D7A28F600E207CA /* Test_Duration.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Duration.swift /* Test_Duration.swift */; };
+		9C8CDA2A1D7A28F600E207CA /* Test_Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Empty.swift /* Test_Empty.swift */; };
+		9C8CDA2B1D7A28F600E207CA /* Test_Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Enum.swift /* Test_Enum.swift */; };
+		9C8CDA2C1D7A28F600E207CA /* Test_Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Extensions.swift /* Test_Extensions.swift */; };
+		9C8CDA2D1D7A28F600E207CA /* Test_ExtremeDefaultValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_ExtremeDefaultValues.swift /* Test_ExtremeDefaultValues.swift */; };
+		9C8CDA2E1D7A28F600E207CA /* Test_FieldMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_FieldMask.swift /* Test_FieldMask.swift */; };
+		9C8CDA2F1D7A28F600E207CA /* Test_FieldOrdering.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_FieldOrdering.swift /* Test_FieldOrdering.swift */; };
+		9C8CDA301D7A28F600E207CA /* Test_JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_JSON.swift /* Test_JSON.swift */; };
+		9C8CDA311D7A28F600E207CA /* Test_JSON_Conformance.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_JSON_Conformance.swift /* Test_JSON_Conformance.swift */; };
+		9C8CDA321D7A28F600E207CA /* Test_JSON_Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_JSON_Group.swift /* Test_JSON_Group.swift */; };
+		9C8CDA341D7A28F600E207CA /* Test_Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Map.swift /* Test_Map.swift */; };
+		9C8CDA351D7A28F600E207CA /* Test_Map_JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Map_JSON.swift /* Test_Map_JSON.swift */; };
+		9C8CDA361D7A28F600E207CA /* Test_Packed.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Packed.swift /* Test_Packed.swift */; };
+		9C8CDA371D7A28F600E207CA /* Test_ParsingMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_ParsingMerge.swift /* Test_ParsingMerge.swift */; };
+		9C8CDA391D7A28F600E207CA /* Test_ReallyLargeTagNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_ReallyLargeTagNumber.swift /* Test_ReallyLargeTagNumber.swift */; };
+		9C8CDA3A1D7A28F600E207CA /* Test_RecursiveMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_RecursiveMap.swift /* Test_RecursiveMap.swift */; };
+		9C8CDA3B1D7A28F600E207CA /* Test_Required.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Required.swift /* Test_Required.swift */; };
+		9C8CDA3C1D7A28F600E207CA /* Test_Reserved.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Reserved.swift /* Test_Reserved.swift */; };
+		9C8CDA3D1D7A28F600E207CA /* Test_Struct.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Struct.swift /* Test_Struct.swift */; };
+		9C8CDA3E1D7A28F600E207CA /* Test_Timestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Timestamp.swift /* Test_Timestamp.swift */; };
+		9C8CDA3F1D7A28F600E207CA /* Test_Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Type.swift /* Test_Type.swift */; };
+		9C8CDA401D7A28F600E207CA /* Test_Unknown_proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto2.swift /* Test_Unknown_proto2.swift */; };
+		9C8CDA411D7A28F600E207CA /* Test_Unknown_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto3.swift /* Test_Unknown_proto3.swift */; };
+		9C8CDA421D7A28F600E207CA /* Test_Wrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Wrappers.swift /* Test_Wrappers.swift */; };
+		9C8CDA431D7A28F600E207CA /* unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest.pb.swift /* unittest.pb.swift */; };
+		9C8CDA441D7A28F600E207CA /* unittest_arena.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_arena.pb.swift /* unittest_arena.pb.swift */; };
+		9C8CDA451D7A28F600E207CA /* unittest_custom_options.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_custom_options.pb.swift /* unittest_custom_options.pb.swift */; };
+		9C8CDA461D7A28F600E207CA /* unittest_drop_unknown_fields.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_drop_unknown_fields.pb.swift /* unittest_drop_unknown_fields.pb.swift */; };
+		9C8CDA471D7A28F600E207CA /* unittest_embed_optimize_for.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_embed_optimize_for.pb.swift /* unittest_embed_optimize_for.pb.swift */; };
+		9C8CDA481D7A28F600E207CA /* unittest_empty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_empty.pb.swift /* unittest_empty.pb.swift */; };
+		9C8CDA491D7A28F600E207CA /* unittest_import.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_import.pb.swift /* unittest_import.pb.swift */; };
+		9C8CDA4A1D7A28F600E207CA /* unittest_import_lite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_import_lite.pb.swift /* unittest_import_lite.pb.swift */; };
+		9C8CDA4C1D7A28F600E207CA /* unittest_import_public.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_import_public.pb.swift /* unittest_import_public.pb.swift */; };
+		9C8CDA4D1D7A28F600E207CA /* unittest_import_public_lite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_import_public_lite.pb.swift /* unittest_import_public_lite.pb.swift */; };
+		9C8CDA4F1D7A28F600E207CA /* unittest_lite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_lite.pb.swift /* unittest_lite.pb.swift */; };
+		9C8CDA501D7A28F600E207CA /* unittest_lite_imports_nonlite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_lite_imports_nonlite.pb.swift /* unittest_lite_imports_nonlite.pb.swift */; };
+		9C8CDA511D7A28F600E207CA /* unittest_mset.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_mset.pb.swift /* unittest_mset.pb.swift */; };
+		9C8CDA521D7A28F600E207CA /* unittest_mset_wire_format.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_mset_wire_format.pb.swift /* unittest_mset_wire_format.pb.swift */; };
+		9C8CDA531D7A28F600E207CA /* unittest_no_arena.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_arena.pb.swift /* unittest_no_arena.pb.swift */; };
+		9C8CDA541D7A28F600E207CA /* unittest_no_arena_import.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_arena_import.pb.swift /* unittest_no_arena_import.pb.swift */; };
+		9C8CDA551D7A28F600E207CA /* unittest_no_arena_lite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_arena_lite.pb.swift /* unittest_no_arena_lite.pb.swift */; };
+		9C8CDA561D7A28F600E207CA /* unittest_no_field_presence.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_field_presence.pb.swift /* unittest_no_field_presence.pb.swift */; };
+		9C8CDA571D7A28F600E207CA /* unittest_no_generic_services.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_generic_services.pb.swift /* unittest_no_generic_services.pb.swift */; };
+		9C8CDA581D7A28F600E207CA /* unittest_optimize_for.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_optimize_for.pb.swift /* unittest_optimize_for.pb.swift */; };
+		9C8CDA591D7A28F600E207CA /* unittest_preserve_unknown_enum.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_preserve_unknown_enum.pb.swift /* unittest_preserve_unknown_enum.pb.swift */; };
+		9C8CDA5A1D7A28F600E207CA /* unittest_preserve_unknown_enum2.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_preserve_unknown_enum2.pb.swift /* unittest_preserve_unknown_enum2.pb.swift */; };
+		9C8CDA5B1D7A28F600E207CA /* unittest_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_proto3.pb.swift /* unittest_proto3.pb.swift */; };
+		9C8CDA5C1D7A28F600E207CA /* unittest_proto3_arena.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_proto3_arena.pb.swift /* unittest_proto3_arena.pb.swift */; };
+		9C8CDA5D1D7A28F600E207CA /* unittest_swift_all_required_types.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_all_required_types.pb.swift /* unittest_swift_all_required_types.pb.swift */; };
+		9C8CDA5E1D7A28F600E207CA /* unittest_swift_cycle.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_cycle.pb.swift /* unittest_swift_cycle.pb.swift */; };
+		9C8CDA5F1D7A28F600E207CA /* unittest_swift_enum.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_enum.pb.swift /* unittest_swift_enum.pb.swift */; };
+		9C8CDA601D7A28F600E207CA /* unittest_swift_enum_optional_default.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_enum_optional_default.pb.swift /* unittest_swift_enum_optional_default.pb.swift */; };
+		9C8CDA611D7A28F600E207CA /* unittest_swift_extension.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_extension.pb.swift /* unittest_swift_extension.pb.swift */; };
+		9C8CDA621D7A28F600E207CA /* unittest_swift_fieldorder.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_fieldorder.pb.swift /* unittest_swift_fieldorder.pb.swift */; };
+		9C8CDA631D7A28F600E207CA /* unittest_swift_groups.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_groups.pb.swift /* unittest_swift_groups.pb.swift */; };
+		9C8CDA641D7A28F600E207CA /* unittest_swift_naming.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_naming.pb.swift /* unittest_swift_naming.pb.swift */; };
+		9C8CDA651D7A28F600E207CA /* unittest_swift_performance.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_performance.pb.swift /* unittest_swift_performance.pb.swift */; };
+		9C8CDA661D7A28F600E207CA /* unittest_swift_reserved.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_reserved.pb.swift /* unittest_swift_reserved.pb.swift */; };
+		9C8CDA671D7A28F600E207CA /* unittest_swift_runtime_proto2.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_runtime_proto2.pb.swift /* unittest_swift_runtime_proto2.pb.swift */; };
+		9C8CDA681D7A28F600E207CA /* unittest_swift_runtime_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_runtime_proto3.pb.swift /* unittest_swift_runtime_proto3.pb.swift */; };
+		9C8CDA691D7A28F600E207CA /* unittest_swift_startup.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_startup.pb.swift /* unittest_swift_startup.pb.swift */; };
+		9C8CDA6A1D7A28F600E207CA /* unittest_well_known_types.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_well_known_types.pb.swift /* unittest_well_known_types.pb.swift */; };
+		9CA424421E286D4E00C0E5B4 /* StringUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA424411E286D4E00C0E5B4 /* StringUtils.swift */; };
+		9CA424431E286D4E00C0E5B4 /* StringUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA424411E286D4E00C0E5B4 /* StringUtils.swift */; };
+		9CA424441E286D4E00C0E5B4 /* StringUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA424411E286D4E00C0E5B4 /* StringUtils.swift */; };
+		9CA424451E286D4E00C0E5B4 /* StringUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA424411E286D4E00C0E5B4 /* StringUtils.swift */; };
+		9CC8CAAC1EC512A0008EF45F /* generated_swift_names_enum_cases.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC8CAA81EC512A0008EF45F /* generated_swift_names_enum_cases.pb.swift */; };
+		9CC8CAAD1EC512A0008EF45F /* generated_swift_names_enum_cases.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC8CAA81EC512A0008EF45F /* generated_swift_names_enum_cases.pb.swift */; };
+		9CC8CAAE1EC512A0008EF45F /* generated_swift_names_enum_cases.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC8CAA81EC512A0008EF45F /* generated_swift_names_enum_cases.pb.swift */; };
+		9CC8CAAF1EC512A0008EF45F /* generated_swift_names_enums.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC8CAA91EC512A0008EF45F /* generated_swift_names_enums.pb.swift */; };
+		9CC8CAB01EC512A0008EF45F /* generated_swift_names_enums.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC8CAA91EC512A0008EF45F /* generated_swift_names_enums.pb.swift */; };
+		9CC8CAB11EC512A0008EF45F /* generated_swift_names_enums.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC8CAA91EC512A0008EF45F /* generated_swift_names_enums.pb.swift */; };
+		9CC8CAB21EC512A0008EF45F /* generated_swift_names_fields.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC8CAAA1EC512A0008EF45F /* generated_swift_names_fields.pb.swift */; };
+		9CC8CAB31EC512A0008EF45F /* generated_swift_names_fields.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC8CAAA1EC512A0008EF45F /* generated_swift_names_fields.pb.swift */; };
+		9CC8CAB41EC512A0008EF45F /* generated_swift_names_fields.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC8CAAA1EC512A0008EF45F /* generated_swift_names_fields.pb.swift */; };
+		9CC8CAB51EC512A0008EF45F /* generated_swift_names_messages.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC8CAAB1EC512A0008EF45F /* generated_swift_names_messages.pb.swift */; };
+		9CC8CAB61EC512A0008EF45F /* generated_swift_names_messages.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC8CAAB1EC512A0008EF45F /* generated_swift_names_messages.pb.swift */; };
+		9CC8CAB71EC512A0008EF45F /* generated_swift_names_messages.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC8CAAB1EC512A0008EF45F /* generated_swift_names_messages.pb.swift */; };
+		9CCD5F931E008203002D1940 /* Test_TextFormat_WKT_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CCD5F921E008203002D1940 /* Test_TextFormat_WKT_proto3.swift */; };
+		9CCD5F941E008203002D1940 /* Test_TextFormat_WKT_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CCD5F921E008203002D1940 /* Test_TextFormat_WKT_proto3.swift */; };
+		9CCD5F951E008203002D1940 /* Test_TextFormat_WKT_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CCD5F921E008203002D1940 /* Test_TextFormat_WKT_proto3.swift */; };
+		9CE9CF371E32C9F8004FBED6 /* JSONScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE9CF361E32C9F8004FBED6 /* JSONScanner.swift */; };
+		9CEB0D681DF5E934002D80F0 /* TextFormatEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEB0D671DF5E934002D80F0 /* TextFormatEncodingVisitor.swift */; };
+		9CEB0D6C1DF5F921002D80F0 /* TextFormatScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEB0D6B1DF5F921002D80F0 /* TextFormatScanner.swift */; };
+		AA05BF4A1DAEB7E400619042 /* WireFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF491DAEB7E400619042 /* WireFormat.swift */; };
+		AA05BF4B1DAEB7E400619042 /* WireFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF491DAEB7E400619042 /* WireFormat.swift */; };
+		AA05BF4C1DAEB7E400619042 /* WireFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF491DAEB7E400619042 /* WireFormat.swift */; };
+		AA05BF4D1DAEB7E400619042 /* WireFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF491DAEB7E400619042 /* WireFormat.swift */; };
+		AA05BF4F1DAEB7E800619042 /* FieldTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF4E1DAEB7E800619042 /* FieldTag.swift */; };
+		AA05BF501DAEB7E800619042 /* FieldTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF4E1DAEB7E800619042 /* FieldTag.swift */; };
+		AA05BF511DAEB7E800619042 /* FieldTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF4E1DAEB7E800619042 /* FieldTag.swift */; };
+		AA05BF521DAEB7E800619042 /* FieldTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF4E1DAEB7E800619042 /* FieldTag.swift */; };
+		AA28A4A61DA30E5900C866D9 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A51DA30E5900C866D9 /* ZigZag.swift */; };
+		AA28A4A71DA30E5900C866D9 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A51DA30E5900C866D9 /* ZigZag.swift */; };
+		AA28A4A91DA40B0900C866D9 /* Varint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A81DA40B0900C866D9 /* Varint.swift */; };
+		AA28A4AA1DA40B0900C866D9 /* Varint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A81DA40B0900C866D9 /* Varint.swift */; };
+		AA28A4AC1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4AB1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift */; };
+		AA28A4AD1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4AB1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift */; };
+		AA3640911E60D043000C3CF4 /* struct.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3640901E60D043000C3CF4 /* struct.pb.swift */; };
+		AA3640921E60D592000C3CF4 /* struct.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3640901E60D043000C3CF4 /* struct.pb.swift */; };
+		AA3640931E60D593000C3CF4 /* struct.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3640901E60D043000C3CF4 /* struct.pb.swift */; };
+		AA3640941E60D593000C3CF4 /* struct.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3640901E60D043000C3CF4 /* struct.pb.swift */; };
+		AA3640961E60EBB0000C3CF4 /* Test_Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3640951E60EBB0000C3CF4 /* Test_Merge.swift */; };
+		AA3640971E60EBB0000C3CF4 /* Test_Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3640951E60EBB0000C3CF4 /* Test_Merge.swift */; };
+		AA3640981E60EBB0000C3CF4 /* Test_Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3640951E60EBB0000C3CF4 /* Test_Merge.swift */; };
+		AA6CF6F51DB6D227007DF26B /* Test_Enum_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6CF6F01DB6D1F8007DF26B /* Test_Enum_Proto2.swift */; };
+		AA6CF6F61DB6D228007DF26B /* Test_Enum_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6CF6F01DB6D1F8007DF26B /* Test_Enum_Proto2.swift */; };
+		AA6CF6F71DB6D229007DF26B /* Test_Enum_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6CF6F01DB6D1F8007DF26B /* Test_Enum_Proto2.swift */; };
+		AA78AD361E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA78AD351E84C5B4001C43F9 /* Message+AnyAdditions.swift */; };
+		AA78AD371E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA78AD351E84C5B4001C43F9 /* Message+AnyAdditions.swift */; };
+		AA78AD381E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA78AD351E84C5B4001C43F9 /* Message+AnyAdditions.swift */; };
+		AA78AD391E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA78AD351E84C5B4001C43F9 /* Message+AnyAdditions.swift */; };
+		AA86F6FA1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA86F6F91E0A0F0B006CC38A /* JSONEncodingVisitor.swift */; };
+		AA86F6FB1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA86F6F91E0A0F0B006CC38A /* JSONEncodingVisitor.swift */; };
+		AA86F6FC1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA86F6F91E0A0F0B006CC38A /* JSONEncodingVisitor.swift */; };
+		AA86F6FD1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA86F6F91E0A0F0B006CC38A /* JSONEncodingVisitor.swift */; };
+		AAABA40B1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAABA40A1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift */; };
+		AAABA40C1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAABA40A1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift */; };
+		AAABA40D1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAABA40A1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift */; };
+		AAABA40E1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAABA40A1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift */; };
+		AAB979F51E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB979F41E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift */; };
+		AAB979F61E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB979F41E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift */; };
+		AAB979F71E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB979F41E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift */; };
+		AAB979F81E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB979F41E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift */; };
+		AAE0F4DF1E6A3886005240E0 /* Test_EnumWithAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE0F4DE1E6A3886005240E0 /* Test_EnumWithAliases.swift */; };
+		AAE0F4E01E6A3886005240E0 /* Test_EnumWithAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE0F4DE1E6A3886005240E0 /* Test_EnumWithAliases.swift */; };
+		AAE0F4E11E6A3886005240E0 /* Test_EnumWithAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE0F4DE1E6A3886005240E0 /* Test_EnumWithAliases.swift */; };
+		AAE0F4E31E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE0F4E21E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift */; };
+		AAE0F4E41E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE0F4E21E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift */; };
+		AAE0F4E51E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE0F4E21E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift */; };
+		AAE0F4E61E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE0F4E21E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift */; };
+		AAEA52201DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA521F1DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift */; };
+		AAEA52211DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA521F1DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift */; };
+		AAEA52721DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52711DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift */; };
+		AAEA52741DA80DEA003F318F /* wrappers.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52731DA80DEA003F318F /* wrappers.pb.swift */; };
+		AAEA52771DA832A8003F318F /* wrappers.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52731DA80DEA003F318F /* wrappers.pb.swift */; };
+		AAF2ED3A1DEF3FBC007B510F /* NameMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2ED391DEF3FBC007B510F /* NameMap.swift */; };
+		AAF2ED3B1DEF3FBC007B510F /* NameMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2ED391DEF3FBC007B510F /* NameMap.swift */; };
+		AAF2ED3C1DEF3FBC007B510F /* NameMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2ED391DEF3FBC007B510F /* NameMap.swift */; };
+		AAF2ED3D1DEF3FBC007B510F /* NameMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2ED391DEF3FBC007B510F /* NameMap.swift */; };
+		AAF2ED3F1DEF4D94007B510F /* ProtoNameProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2ED3E1DEF4D94007B510F /* ProtoNameProviding.swift */; };
+		AAF2ED401DEF4D94007B510F /* ProtoNameProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2ED3E1DEF4D94007B510F /* ProtoNameProviding.swift */; };
+		AAF2ED411DEF4D94007B510F /* ProtoNameProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2ED3E1DEF4D94007B510F /* ProtoNameProviding.swift */; };
+		AAF2ED421DEF4D94007B510F /* ProtoNameProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2ED3E1DEF4D94007B510F /* ProtoNameProviding.swift */; };
+		BCCA0E691DB1210E00957D74 /* TextFormatDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E661DB1210E00957D74 /* TextFormatDecoder.swift */; };
+		BCCA0E6A1DB1210E00957D74 /* TextFormatEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E671DB1210E00957D74 /* TextFormatEncoder.swift */; };
+		BCCA0E6B1DB1210E00957D74 /* Message+TextFormatAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E681DB1210E00957D74 /* Message+TextFormatAdditions.swift */; };
+		BCCA0E7A1DB124B800957D74 /* Test_TextFormat_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E751DB123F800957D74 /* Test_TextFormat_proto3.swift */; };
+		DB2E0AFA1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */; };
+		DB2E0AFB1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */; };
+		DB2E0AFC1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */; };
+		DB2E0AFE1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */; };
+		DB2E0AFF1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */; };
+		DB2E0B001EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */; };
+		DB2E0B011EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */; };
+		E7038A24224D7F1000B68775 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7038A23224D7F1000B68775 /* Data+Extensions.swift */; };
+		E7038A25224D7F1000B68775 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7038A23224D7F1000B68775 /* Data+Extensions.swift */; };
+		E7038A26224D7F1000B68775 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7038A23224D7F1000B68775 /* Data+Extensions.swift */; };
+		E7038A27224D7F1000B68775 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7038A23224D7F1000B68775 /* Data+Extensions.swift */; };
+		ECBC5C491DF6ABC500F658E8 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52711DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift */; };
+		ECBC5C4A1DF6ABC500F658E8 /* Google_Protobuf_Struct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct+Extensions.swift */; };
+		ECBC5C4B1DF6ABC500F658E8 /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */; };
+		ECBC5C4C1DF6ABC500F658E8 /* Varint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A81DA40B0900C866D9 /* Varint.swift */; };
+		ECBC5C4D1DF6ABC500F658E8 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Timestamp_Extensions.swift /* Google_Protobuf_Timestamp+Extensions.swift */; };
+		ECBC5C4E1DF6ABC500F658E8 /* type.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */; };
+		ECBC5C4F1DF6ABC500F658E8 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A51DA30E5900C866D9 /* ZigZag.swift */; };
+		ECBC5C501DF6ABC500F658E8 /* source_context.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */; };
+		ECBC5C511DF6ABC500F658E8 /* wrappers.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52731DA80DEA003F318F /* wrappers.pb.swift */; };
+		F40D33EA2017ED2100ABAF0F /* unittest_swift_enum_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40D33E82017ECD300ABAF0F /* unittest_swift_enum_proto3.pb.swift */; };
+		F40D33EB2017ED2200ABAF0F /* unittest_swift_enum_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40D33E82017ECD300ABAF0F /* unittest_swift_enum_proto3.pb.swift */; };
+		F40D33EC2017ED2300ABAF0F /* unittest_swift_enum_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40D33E82017ECD300ABAF0F /* unittest_swift_enum_proto3.pb.swift */; };
+		F411FE9C1EDDD706001AE6B2 /* JSONDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4584DB71EDDCAD600803AB6 /* JSONDecodingOptions.swift */; };
+		F411FE9D1EDDD706001AE6B2 /* JSONDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4584DB71EDDCAD600803AB6 /* JSONDecodingOptions.swift */; };
+		F411FE9E1EDDD707001AE6B2 /* JSONDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4584DB71EDDCAD600803AB6 /* JSONDecodingOptions.swift */; };
+		F411FE9F1EDDD83B001AE6B2 /* BinaryDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F411FE941EDDD6AA001AE6B2 /* BinaryDecodingOptions.swift */; };
+		F411FEA01EDDD83C001AE6B2 /* BinaryDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F411FE941EDDD6AA001AE6B2 /* BinaryDecodingOptions.swift */; };
+		F411FEA11EDDD83D001AE6B2 /* BinaryDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F411FE941EDDD6AA001AE6B2 /* BinaryDecodingOptions.swift */; };
+		F411FEA21EDDD83E001AE6B2 /* BinaryDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F411FE941EDDD6AA001AE6B2 /* BinaryDecodingOptions.swift */; };
+		F411FEAC1EDDDC61001AE6B2 /* Test_BinaryDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F411FEAA1EDDDC5D001AE6B2 /* Test_BinaryDecodingOptions.swift */; };
+		F411FEAD1EDDDC61001AE6B2 /* Test_BinaryDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F411FEAA1EDDDC5D001AE6B2 /* Test_BinaryDecodingOptions.swift */; };
+		F411FEAE1EDDDC62001AE6B2 /* Test_BinaryDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F411FEAA1EDDDC5D001AE6B2 /* Test_BinaryDecodingOptions.swift */; };
+		F4151F661EF3197100EEA00B /* Test_SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4151F641EF3193F00EEA00B /* Test_SimpleExtensionMap.swift */; };
+		F4151F671EF3197200EEA00B /* Test_SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4151F641EF3193F00EEA00B /* Test_SimpleExtensionMap.swift */; };
+		F4151F681EF3197300EEA00B /* Test_SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4151F641EF3193F00EEA00B /* Test_SimpleExtensionMap.swift */; };
+		F4151F711EFAB83400EEA00B /* BinaryDelimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4151F701EFAB83400EEA00B /* BinaryDelimited.swift */; };
+		F4151F721EFAB83900EEA00B /* BinaryDelimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4151F701EFAB83400EEA00B /* BinaryDelimited.swift */; };
+		F4151F731EFAB83A00EEA00B /* BinaryDelimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4151F701EFAB83400EEA00B /* BinaryDelimited.swift */; };
+		F4151F741EFAB83A00EEA00B /* BinaryDelimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4151F701EFAB83400EEA00B /* BinaryDelimited.swift */; };
+		F4151F771EFAD85A00EEA00B /* Test_BinaryDelimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4151F751EFAD85600EEA00B /* Test_BinaryDelimited.swift */; };
+		F4151F781EFAD85B00EEA00B /* Test_BinaryDelimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4151F751EFAD85600EEA00B /* Test_BinaryDelimited.swift */; };
+		F4151F791EFAD85C00EEA00B /* Test_BinaryDelimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4151F751EFAD85600EEA00B /* Test_BinaryDelimited.swift */; };
+		F41BA3FC1E76F635004F6E95 /* Google_Protobuf_Any+Registry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA3FB1E76F635004F6E95 /* Google_Protobuf_Any+Registry.swift */; };
+		F41BA3FD1E76F639004F6E95 /* Google_Protobuf_Any+Registry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA3FB1E76F635004F6E95 /* Google_Protobuf_Any+Registry.swift */; };
+		F41BA3FE1E76F639004F6E95 /* Google_Protobuf_Any+Registry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA3FB1E76F635004F6E95 /* Google_Protobuf_Any+Registry.swift */; };
+		F41BA3FF1E76F63A004F6E95 /* Google_Protobuf_Any+Registry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA3FB1E76F635004F6E95 /* Google_Protobuf_Any+Registry.swift */; };
+		F41BA4131E79BDCA004F6E95 /* Google_Protobuf_Any+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA4121E79BDCA004F6E95 /* Google_Protobuf_Any+Extensions.swift */; };
+		F41BA4141E79BE54004F6E95 /* Google_Protobuf_Any+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA4121E79BDCA004F6E95 /* Google_Protobuf_Any+Extensions.swift */; };
+		F41BA4151E79BE55004F6E95 /* Google_Protobuf_Any+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA4121E79BDCA004F6E95 /* Google_Protobuf_Any+Extensions.swift */; };
+		F41BA4161E79BE56004F6E95 /* Google_Protobuf_Any+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA4121E79BDCA004F6E95 /* Google_Protobuf_Any+Extensions.swift */; };
+		F41BA4181E79C568004F6E95 /* AnyUnpackError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA4171E79C568004F6E95 /* AnyUnpackError.swift */; };
+		F41BA4191E79C59A004F6E95 /* AnyUnpackError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA4171E79C568004F6E95 /* AnyUnpackError.swift */; };
+		F41BA41A1E79C59B004F6E95 /* AnyUnpackError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA4171E79C568004F6E95 /* AnyUnpackError.swift */; };
+		F41BA41B1E79C59B004F6E95 /* AnyUnpackError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA4171E79C568004F6E95 /* AnyUnpackError.swift */; };
+		F41BA4401E7AE4AC004F6E95 /* any.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA43F1E7AE4AC004F6E95 /* any.pb.swift */; };
+		F41BA4421E7AE53C004F6E95 /* AnyMessageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA4411E7AE53C004F6E95 /* AnyMessageStorage.swift */; };
+		F41BA4431E7B35C6004F6E95 /* AnyMessageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA4411E7AE53C004F6E95 /* AnyMessageStorage.swift */; };
+		F41BA4441E7B35C7004F6E95 /* AnyMessageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA4411E7AE53C004F6E95 /* AnyMessageStorage.swift */; };
+		F41BA4451E7B35C8004F6E95 /* AnyMessageStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41BA4411E7AE53C004F6E95 /* AnyMessageStorage.swift */; };
+		F44F93691DAD7FA500BC5B85 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52711DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift */; };
+		F44F93771DAEA76700BC5B85 /* api.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/api.pb.swift /* api.pb.swift */; };
+		F44F93781DAEA76700BC5B85 /* duration.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/duration.pb.swift /* duration.pb.swift */; };
+		F44F93791DAEA76700BC5B85 /* empty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/empty.pb.swift /* empty.pb.swift */; };
+		F44F937A1DAEA76700BC5B85 /* field_mask.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/field_mask.pb.swift /* field_mask.pb.swift */; };
+		F44F937C1DAEA76700BC5B85 /* Google_Protobuf_Duration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration+Extensions.swift */; };
+		F44F937D1DAEA76700BC5B85 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_FieldMask_Extensions.swift /* Google_Protobuf_FieldMask+Extensions.swift */; };
+		F44F937E1DAEA76700BC5B85 /* Google_Protobuf_Struct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct+Extensions.swift */; };
+		F44F937F1DAEA76700BC5B85 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Timestamp_Extensions.swift /* Google_Protobuf_Timestamp+Extensions.swift */; };
+		F44F93801DAEA76700BC5B85 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52711DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift */; };
+		F44F93811DAEA76700BC5B85 /* BinaryDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* BinaryDecoder.swift */; };
+		F44F93821DAEA76700BC5B85 /* BinaryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift */; };
+		F44F93831DAEA76700BC5B85 /* BinaryEncodingSizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4AB1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift */; };
+		F44F93841DAEA76700BC5B85 /* Message+BinaryAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* Message+BinaryAdditions.swift */; };
+		F44F93861DAEA76700BC5B85 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */; };
+		F44F93881DAEA76700BC5B85 /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */; };
+		F44F93891DAEA76700BC5B85 /* MessageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift */; };
+		F44F938A1DAEA76700BC5B85 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */; };
+		F44F938B1DAEA76700BC5B85 /* HashVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufHash.swift /* HashVisitor.swift */; };
+		F44F938D1DAEA76700BC5B85 /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufJSONEncoding.swift /* JSONEncoder.swift */; };
+		F44F938E1DAEA76700BC5B85 /* Message+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufJSONTypes.swift /* Message+JSONAdditions.swift */; };
+		F44F938F1DAEA76700BC5B85 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufMessage.swift /* Message.swift */; };
+		F44F93931DAEA76700BC5B85 /* FieldTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufTypes.swift /* FieldTypes.swift */; };
+		F44F93941DAEA76700BC5B85 /* UnknownStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufUnknown.swift /* UnknownStorage.swift */; };
+		F44F93951DAEA76700BC5B85 /* source_context.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */; };
+		F44F93961DAEA76700BC5B85 /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */; };
+		F44F93971DAEA76700BC5B85 /* type.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */; };
+		F44F93981DAEA76700BC5B85 /* Varint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A81DA40B0900C866D9 /* Varint.swift */; };
+		F44F93991DAEA76700BC5B85 /* wrappers.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52731DA80DEA003F318F /* wrappers.pb.swift */; };
+		F44F939A1DAEA76700BC5B85 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A51DA30E5900C866D9 /* ZigZag.swift */; };
+		F44F93A41DAEA7C500BC5B85 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F44F936F1DAEA53900BC5B85 /* SwiftProtobuf.framework */; };
+		F44F93AA1DAEA8C900BC5B85 /* any_test.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift */; };
+		F44F93AB1DAEA8C900BC5B85 /* conformance.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift */; };
+		F44F93AD1DAEA8C900BC5B85 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */; };
+		F44F93AF1DAEA8C900BC5B85 /* map_unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */; };
+		F44F93B01DAEA8C900BC5B85 /* Message+UInt8ArrayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA521F1DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift */; };
+		F44F93B11DAEA8C900BC5B85 /* Test_AllTypes_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */; };
+		F44F93B21DAEA8C900BC5B85 /* Test_AllTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */; };
+		F44F93B31DAEA8C900BC5B85 /* Test_Any.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */; };
+		F44F93B41DAEA8C900BC5B85 /* Test_Api.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Api.swift /* Test_Api.swift */; };
+		F44F93B51DAEA8C900BC5B85 /* Test_Conformance.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Conformance.swift /* Test_Conformance.swift */; };
+		F44F93B71DAEA8C900BC5B85 /* Test_Duration.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Duration.swift /* Test_Duration.swift */; };
+		F44F93B81DAEA8C900BC5B85 /* Test_Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Empty.swift /* Test_Empty.swift */; };
+		F44F93B91DAEA8C900BC5B85 /* Test_Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Enum.swift /* Test_Enum.swift */; };
+		F44F93BA1DAEA8C900BC5B85 /* Test_Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Extensions.swift /* Test_Extensions.swift */; };
+		F44F93BB1DAEA8C900BC5B85 /* Test_ExtremeDefaultValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_ExtremeDefaultValues.swift /* Test_ExtremeDefaultValues.swift */; };
+		F44F93BC1DAEA8C900BC5B85 /* Test_FieldMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_FieldMask.swift /* Test_FieldMask.swift */; };
+		F44F93BD1DAEA8C900BC5B85 /* Test_FieldOrdering.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_FieldOrdering.swift /* Test_FieldOrdering.swift */; };
+		F44F93BE1DAEA8C900BC5B85 /* Test_JSON_Conformance.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_JSON_Conformance.swift /* Test_JSON_Conformance.swift */; };
+		F44F93BF1DAEA8C900BC5B85 /* Test_JSON_Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_JSON_Group.swift /* Test_JSON_Group.swift */; };
+		F44F93C11DAEA8C900BC5B85 /* Test_JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_JSON.swift /* Test_JSON.swift */; };
+		F44F93C21DAEA8C900BC5B85 /* Test_Map_JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Map_JSON.swift /* Test_Map_JSON.swift */; };
+		F44F93C31DAEA8C900BC5B85 /* Test_Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Map.swift /* Test_Map.swift */; };
+		F44F93C41DAEA8C900BC5B85 /* Test_Packed.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Packed.swift /* Test_Packed.swift */; };
+		F44F93C51DAEA8C900BC5B85 /* Test_ParsingMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_ParsingMerge.swift /* Test_ParsingMerge.swift */; };
+		F44F93C71DAEA8C900BC5B85 /* Test_ReallyLargeTagNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_ReallyLargeTagNumber.swift /* Test_ReallyLargeTagNumber.swift */; };
+		F44F93C81DAEA8C900BC5B85 /* Test_RecursiveMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_RecursiveMap.swift /* Test_RecursiveMap.swift */; };
+		F44F93C91DAEA8C900BC5B85 /* Test_Required.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Required.swift /* Test_Required.swift */; };
+		F44F93CA1DAEA8C900BC5B85 /* Test_Reserved.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Reserved.swift /* Test_Reserved.swift */; };
+		F44F93CB1DAEA8C900BC5B85 /* Test_Struct.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Struct.swift /* Test_Struct.swift */; };
+		F44F93CC1DAEA8C900BC5B85 /* Test_Timestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Timestamp.swift /* Test_Timestamp.swift */; };
+		F44F93CD1DAEA8C900BC5B85 /* Test_Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Type.swift /* Test_Type.swift */; };
+		F44F93CE1DAEA8C900BC5B85 /* Test_Unknown_proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto2.swift /* Test_Unknown_proto2.swift */; };
+		F44F93CF1DAEA8C900BC5B85 /* Test_Unknown_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto3.swift /* Test_Unknown_proto3.swift */; };
+		F44F93D01DAEA8C900BC5B85 /* Test_Wrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Wrappers.swift /* Test_Wrappers.swift */; };
+		F44F93D11DAEA8C900BC5B85 /* unittest_arena.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_arena.pb.swift /* unittest_arena.pb.swift */; };
+		F44F93D21DAEA8C900BC5B85 /* unittest_custom_options.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_custom_options.pb.swift /* unittest_custom_options.pb.swift */; };
+		F44F93D31DAEA8C900BC5B85 /* unittest_drop_unknown_fields.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_drop_unknown_fields.pb.swift /* unittest_drop_unknown_fields.pb.swift */; };
+		F44F93D41DAEA8C900BC5B85 /* unittest_embed_optimize_for.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_embed_optimize_for.pb.swift /* unittest_embed_optimize_for.pb.swift */; };
+		F44F93D51DAEA8C900BC5B85 /* unittest_empty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_empty.pb.swift /* unittest_empty.pb.swift */; };
+		F44F93D61DAEA8C900BC5B85 /* unittest_import_lite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_import_lite.pb.swift /* unittest_import_lite.pb.swift */; };
+		F44F93D81DAEA8C900BC5B85 /* unittest_import_public_lite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_import_public_lite.pb.swift /* unittest_import_public_lite.pb.swift */; };
+		F44F93DA1DAEA8C900BC5B85 /* unittest_import_public.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_import_public.pb.swift /* unittest_import_public.pb.swift */; };
+		F44F93DB1DAEA8C900BC5B85 /* unittest_import.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_import.pb.swift /* unittest_import.pb.swift */; };
+		F44F93DC1DAEA8C900BC5B85 /* unittest_lite_imports_nonlite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_lite_imports_nonlite.pb.swift /* unittest_lite_imports_nonlite.pb.swift */; };
+		F44F93DD1DAEA8C900BC5B85 /* unittest_lite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_lite.pb.swift /* unittest_lite.pb.swift */; };
+		F44F93DE1DAEA8C900BC5B85 /* unittest_mset_wire_format.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_mset_wire_format.pb.swift /* unittest_mset_wire_format.pb.swift */; };
+		F44F93DF1DAEA8C900BC5B85 /* unittest_mset.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_mset.pb.swift /* unittest_mset.pb.swift */; };
+		F44F93E01DAEA8C900BC5B85 /* unittest_no_arena_import.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_arena_import.pb.swift /* unittest_no_arena_import.pb.swift */; };
+		F44F93E11DAEA8C900BC5B85 /* unittest_no_arena_lite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_arena_lite.pb.swift /* unittest_no_arena_lite.pb.swift */; };
+		F44F93E21DAEA8C900BC5B85 /* unittest_no_arena.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_arena.pb.swift /* unittest_no_arena.pb.swift */; };
+		F44F93E31DAEA8C900BC5B85 /* unittest_no_field_presence.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_field_presence.pb.swift /* unittest_no_field_presence.pb.swift */; };
+		F44F93E41DAEA8C900BC5B85 /* unittest_no_generic_services.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_generic_services.pb.swift /* unittest_no_generic_services.pb.swift */; };
+		F44F93E51DAEA8C900BC5B85 /* unittest_optimize_for.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_optimize_for.pb.swift /* unittest_optimize_for.pb.swift */; };
+		F44F93E61DAEA8C900BC5B85 /* unittest_preserve_unknown_enum.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_preserve_unknown_enum.pb.swift /* unittest_preserve_unknown_enum.pb.swift */; };
+		F44F93E71DAEA8C900BC5B85 /* unittest_preserve_unknown_enum2.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_preserve_unknown_enum2.pb.swift /* unittest_preserve_unknown_enum2.pb.swift */; };
+		F44F93E81DAEA8C900BC5B85 /* unittest_proto3_arena.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_proto3_arena.pb.swift /* unittest_proto3_arena.pb.swift */; };
+		F44F93E91DAEA8C900BC5B85 /* unittest_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_proto3.pb.swift /* unittest_proto3.pb.swift */; };
+		F44F93EA1DAEA8C900BC5B85 /* unittest_swift_all_required_types.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_all_required_types.pb.swift /* unittest_swift_all_required_types.pb.swift */; };
+		F44F93EB1DAEA8C900BC5B85 /* unittest_swift_cycle.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_cycle.pb.swift /* unittest_swift_cycle.pb.swift */; };
+		F44F93EC1DAEA8C900BC5B85 /* unittest_swift_enum_optional_default.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_enum_optional_default.pb.swift /* unittest_swift_enum_optional_default.pb.swift */; };
+		F44F93ED1DAEA8C900BC5B85 /* unittest_swift_enum.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_enum.pb.swift /* unittest_swift_enum.pb.swift */; };
+		F44F93EE1DAEA8C900BC5B85 /* unittest_swift_extension.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_extension.pb.swift /* unittest_swift_extension.pb.swift */; };
+		F44F93EF1DAEA8C900BC5B85 /* unittest_swift_fieldorder.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_fieldorder.pb.swift /* unittest_swift_fieldorder.pb.swift */; };
+		F44F93F01DAEA8C900BC5B85 /* unittest_swift_groups.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_groups.pb.swift /* unittest_swift_groups.pb.swift */; };
+		F44F93F11DAEA8C900BC5B85 /* unittest_swift_naming.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_naming.pb.swift /* unittest_swift_naming.pb.swift */; };
+		F44F93F21DAEA8C900BC5B85 /* unittest_swift_performance.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_performance.pb.swift /* unittest_swift_performance.pb.swift */; };
+		F44F93F31DAEA8C900BC5B85 /* unittest_swift_reserved.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_reserved.pb.swift /* unittest_swift_reserved.pb.swift */; };
+		F44F93F41DAEA8C900BC5B85 /* unittest_swift_runtime_proto2.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_runtime_proto2.pb.swift /* unittest_swift_runtime_proto2.pb.swift */; };
+		F44F93F51DAEA8C900BC5B85 /* unittest_swift_runtime_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_runtime_proto3.pb.swift /* unittest_swift_runtime_proto3.pb.swift */; };
+		F44F93F61DAEA8C900BC5B85 /* unittest_swift_startup.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_startup.pb.swift /* unittest_swift_startup.pb.swift */; };
+		F44F93F71DAEA8C900BC5B85 /* unittest_well_known_types.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_well_known_types.pb.swift /* unittest_well_known_types.pb.swift */; };
+		F44F93F81DAEA8C900BC5B85 /* unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest.pb.swift /* unittest.pb.swift */; };
+		F44F94061DAEB23500BC5B85 /* api.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/api.pb.swift /* api.pb.swift */; };
+		F44F94071DAEB23500BC5B85 /* duration.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/duration.pb.swift /* duration.pb.swift */; };
+		F44F94081DAEB23500BC5B85 /* empty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/empty.pb.swift /* empty.pb.swift */; };
+		F44F94091DAEB23500BC5B85 /* field_mask.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/field_mask.pb.swift /* field_mask.pb.swift */; };
+		F44F940B1DAEB23500BC5B85 /* Google_Protobuf_Duration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration+Extensions.swift */; };
+		F44F940C1DAEB23500BC5B85 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_FieldMask_Extensions.swift /* Google_Protobuf_FieldMask+Extensions.swift */; };
+		F44F94101DAEB23500BC5B85 /* BinaryDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* BinaryDecoder.swift */; };
+		F44F94111DAEB23500BC5B85 /* BinaryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift */; };
+		F44F94121DAEB23500BC5B85 /* BinaryEncodingSizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4AB1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift */; };
+		F44F94131DAEB23500BC5B85 /* Message+BinaryAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* Message+BinaryAdditions.swift */; };
+		F44F94151DAEB23500BC5B85 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */; };
+		F44F94171DAEB23500BC5B85 /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */; };
+		F44F94181DAEB23500BC5B85 /* MessageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift */; };
+		F44F94191DAEB23500BC5B85 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */; };
+		F44F941A1DAEB23500BC5B85 /* HashVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufHash.swift /* HashVisitor.swift */; };
+		F44F941C1DAEB23500BC5B85 /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufJSONEncoding.swift /* JSONEncoder.swift */; };
+		F44F941D1DAEB23500BC5B85 /* Message+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufJSONTypes.swift /* Message+JSONAdditions.swift */; };
+		F44F941E1DAEB23500BC5B85 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufMessage.swift /* Message.swift */; };
+		F44F94221DAEB23500BC5B85 /* FieldTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufTypes.swift /* FieldTypes.swift */; };
+		F44F94231DAEB23500BC5B85 /* UnknownStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufUnknown.swift /* UnknownStorage.swift */; };
+		F44F94351DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */; };
+		F44F94361DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */; };
+		F44F94371DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */; };
+		F44F943A1DBFBB7400BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */; };
+		F44F943B1DBFBB7500BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */; };
+		F44F943C1DBFBB7700BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */; };
+		F44F943E1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */; };
+		F44F943F1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */; };
+		F44F94401DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */; };
+		F44F94431DBFE0BE00BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */; };
+		F44F94441DBFE0BF00BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */; };
+		F44F94451DBFE0C000BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */; };
+		F44F94481DBFF17F00BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */; };
+		F44F94491DBFF18000BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */; };
+		F44F944A1DBFF18100BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */; };
+		F44F944D1DBFF8DB00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */; };
+		F44F944E1DBFF8DC00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */; };
+		F44F944F1DBFF8DC00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */; };
+		F451074623A288E400488257 /* UnsafeRawPointer+Shims.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451074423A288E400488257 /* UnsafeRawPointer+Shims.swift */; };
+		F451074723A288E400488257 /* UnsafeRawPointer+Shims.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451074423A288E400488257 /* UnsafeRawPointer+Shims.swift */; };
+		F451074823A288E400488257 /* UnsafeRawPointer+Shims.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451074423A288E400488257 /* UnsafeRawPointer+Shims.swift */; };
+		F451074923A288E400488257 /* UnsafeRawPointer+Shims.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451074423A288E400488257 /* UnsafeRawPointer+Shims.swift */; };
+		F451074A23A288E400488257 /* UnsafeBufferPointer+Shims.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451074523A288E400488257 /* UnsafeBufferPointer+Shims.swift */; };
+		F451074B23A288E400488257 /* UnsafeBufferPointer+Shims.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451074523A288E400488257 /* UnsafeBufferPointer+Shims.swift */; };
+		F451074C23A288E400488257 /* UnsafeBufferPointer+Shims.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451074523A288E400488257 /* UnsafeBufferPointer+Shims.swift */; };
+		F451074D23A288E400488257 /* UnsafeBufferPointer+Shims.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451074523A288E400488257 /* UnsafeBufferPointer+Shims.swift */; };
+		F451075823A2B9B500488257 /* Data+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451075723A2B9B500488257 /* Data+TestHelpers.swift */; };
+		F451075923A2B9B500488257 /* Data+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451075723A2B9B500488257 /* Data+TestHelpers.swift */; };
+		F451075A23A2B9B500488257 /* Data+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F451075723A2B9B500488257 /* Data+TestHelpers.swift */; };
+		F4539D261E688B030076251F /* Test_GroupWithGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4539D241E688B000076251F /* Test_GroupWithGroups.swift */; };
+		F4539D271E688B040076251F /* Test_GroupWithGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4539D241E688B000076251F /* Test_GroupWithGroups.swift */; };
+		F4539D281E688B050076251F /* Test_GroupWithGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4539D241E688B000076251F /* Test_GroupWithGroups.swift */; };
+		F4539D2A1E6F5DC70076251F /* CustomJSONCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4539D291E6F5DC70076251F /* CustomJSONCodable.swift */; };
+		F4539D2B1E6F5DD40076251F /* CustomJSONCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4539D291E6F5DC70076251F /* CustomJSONCodable.swift */; };
+		F4539D2C1E6F5DD50076251F /* CustomJSONCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4539D291E6F5DC70076251F /* CustomJSONCodable.swift */; };
+		F4539D2D1E6F5DD60076251F /* CustomJSONCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4539D291E6F5DC70076251F /* CustomJSONCodable.swift */; };
+		F4584D3B1ECA4FC600803AB6 /* unittest_swift_oneof_merging.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4584D391ECA4FB400803AB6 /* unittest_swift_oneof_merging.pb.swift */; };
+		F4584D3C1ECA4FC700803AB6 /* unittest_swift_oneof_merging.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4584D391ECA4FB400803AB6 /* unittest_swift_oneof_merging.pb.swift */; };
+		F4584D3D1ECA4FC800803AB6 /* unittest_swift_oneof_merging.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4584D391ECA4FB400803AB6 /* unittest_swift_oneof_merging.pb.swift */; };
+		F4584DB41EDDCA8700803AB6 /* Test_JSONDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4584DB21EDDC9D400803AB6 /* Test_JSONDecodingOptions.swift */; };
+		F4584DB51EDDCA8800803AB6 /* Test_JSONDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4584DB21EDDC9D400803AB6 /* Test_JSONDecodingOptions.swift */; };
+		F4584DB61EDDCA8900803AB6 /* Test_JSONDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4584DB21EDDC9D400803AB6 /* Test_JSONDecodingOptions.swift */; };
+		F4584DB81EDDCAD600803AB6 /* JSONDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4584DB71EDDCAD600803AB6 /* JSONDecodingOptions.swift */; };
+		F45D73FD1EE9984A00E0A231 /* Test_MessageSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45D73FB1EE994C700E0A231 /* Test_MessageSet.swift */; };
+		F45D73FE1EE9984B00E0A231 /* Test_MessageSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45D73FB1EE994C700E0A231 /* Test_MessageSet.swift */; };
+		F45D73FF1EE9984C00E0A231 /* Test_MessageSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45D73FB1EE994C700E0A231 /* Test_MessageSet.swift */; };
+		F4618B562154151700E5FABA /* JSONEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4618B552154151700E5FABA /* JSONEncodingOptions.swift */; };
+		F4618B572154151700E5FABA /* JSONEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4618B552154151700E5FABA /* JSONEncodingOptions.swift */; };
+		F4618B582154151700E5FABA /* JSONEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4618B552154151700E5FABA /* JSONEncodingOptions.swift */; };
+		F4618B592154151700E5FABA /* JSONEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4618B552154151700E5FABA /* JSONEncodingOptions.swift */; };
+		F4618B642154245600E5FABA /* Test_JSONEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4618B632154245500E5FABA /* Test_JSONEncodingOptions.swift */; };
+		F4618B652154245600E5FABA /* Test_JSONEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4618B632154245500E5FABA /* Test_JSONEncodingOptions.swift */; };
+		F4618B662154245600E5FABA /* Test_JSONEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4618B632154245500E5FABA /* Test_JSONEncodingOptions.swift */; };
+		F47138961E4E56AC00C8492C /* Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47138951E4E56AC00C8492C /* Internal.swift */; };
+		F47138971E4E56AC00C8492C /* Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47138951E4E56AC00C8492C /* Internal.swift */; };
+		F47138981E4E56AC00C8492C /* Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47138951E4E56AC00C8492C /* Internal.swift */; };
+		F47138991E4E56AC00C8492C /* Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47138951E4E56AC00C8492C /* Internal.swift */; };
+		F47C42B52437A3C700C08579 /* unittest_proto3_optional.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47C42B42437A3C700C08579 /* unittest_proto3_optional.pb.swift */; };
+		F47C42B62437A3C700C08579 /* unittest_proto3_optional.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47C42B42437A3C700C08579 /* unittest_proto3_optional.pb.swift */; };
+		F47C42B72437A3C700C08579 /* unittest_proto3_optional.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47C42B42437A3C700C08579 /* unittest_proto3_optional.pb.swift */; };
+		F47C42C22437A73000C08579 /* Test_AllTypes_Proto3_Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47C42C12437A73000C08579 /* Test_AllTypes_Proto3_Optional.swift */; };
+		F47C42C32437A73000C08579 /* Test_AllTypes_Proto3_Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47C42C12437A73000C08579 /* Test_AllTypes_Proto3_Optional.swift */; };
+		F47C42C42437A73000C08579 /* Test_AllTypes_Proto3_Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47C42C12437A73000C08579 /* Test_AllTypes_Proto3_Optional.swift */; };
+		F47CF9A123E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47CF9A023E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift */; };
+		F47CF9A223E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47CF9A023E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift */; };
+		F47CF9A323E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47CF9A023E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift */; };
+		F482B6791E856D2600A25EF8 /* unittest_swift_reserved_ext.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6771E856D1700A25EF8 /* unittest_swift_reserved_ext.pb.swift */; };
+		F482B67A1E856D2700A25EF8 /* unittest_swift_reserved_ext.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6771E856D1700A25EF8 /* unittest_swift_reserved_ext.pb.swift */; };
+		F482B67B1E856D2700A25EF8 /* unittest_swift_reserved_ext.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6771E856D1700A25EF8 /* unittest_swift_reserved_ext.pb.swift */; };
+		F482B6931E857BC100A25EF8 /* unittest_swift_naming_no_prefix.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6911E857BBC00A25EF8 /* unittest_swift_naming_no_prefix.pb.swift */; };
+		F482B6941E857BC100A25EF8 /* unittest_swift_naming_no_prefix.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6911E857BBC00A25EF8 /* unittest_swift_naming_no_prefix.pb.swift */; };
+		F482B6951E857BC200A25EF8 /* unittest_swift_naming_no_prefix.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6911E857BBC00A25EF8 /* unittest_swift_naming_no_prefix.pb.swift */; };
+		F482B6B31E89940E00A25EF8 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6B21E89940E00A25EF8 /* Version.swift */; };
+		F482B6B61E89941500A25EF8 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6B21E89940E00A25EF8 /* Version.swift */; };
+		F482B6B71E89941600A25EF8 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6B21E89940E00A25EF8 /* Version.swift */; };
+		F482B6B81E89941600A25EF8 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6B21E89940E00A25EF8 /* Version.swift */; };
+		F48769F823020B7D00D44224 /* descriptor.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48769F723020B7D00D44224 /* descriptor.pb.swift */; };
+		F48769F923020B7D00D44224 /* descriptor.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48769F723020B7D00D44224 /* descriptor.pb.swift */; };
+		F48769FA23020B7D00D44224 /* descriptor.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48769F723020B7D00D44224 /* descriptor.pb.swift */; };
+		F48769FB23020B7D00D44224 /* descriptor.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48769F723020B7D00D44224 /* descriptor.pb.swift */; };
+		F48FDD241E4D17ED0061D5C1 /* JSONScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE9CF361E32C9F8004FBED6 /* JSONScanner.swift */; };
+		F48FDD251E4D17EE0061D5C1 /* JSONScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE9CF361E32C9F8004FBED6 /* JSONScanner.swift */; };
+		F48FDD261E4D17EF0061D5C1 /* JSONScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE9CF361E32C9F8004FBED6 /* JSONScanner.swift */; };
+		F48FDD271E4D18060061D5C1 /* Test_TextFormat_proto2_extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5890A51DFF5EC8001CFC34 /* Test_TextFormat_proto2_extensions.swift */; };
+		F48FDD281E4D18060061D5C1 /* Test_TextFormat_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E751DB123F800957D74 /* Test_TextFormat_proto3.swift */; };
+		F48FDD291E4D18080061D5C1 /* Test_TextFormat_proto2_extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5890A51DFF5EC8001CFC34 /* Test_TextFormat_proto2_extensions.swift */; };
+		F48FDD2A1E4D18080061D5C1 /* Test_TextFormat_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E751DB123F800957D74 /* Test_TextFormat_proto3.swift */; };
+		F49B576B2252771700350FFD /* TextFormatEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B576A2252771700350FFD /* TextFormatEncodingOptions.swift */; };
+		F49B576C2252771700350FFD /* TextFormatEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B576A2252771700350FFD /* TextFormatEncodingOptions.swift */; };
+		F49B576D2252771700350FFD /* TextFormatEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B576A2252771700350FFD /* TextFormatEncodingOptions.swift */; };
+		F49B576E2252771700350FFD /* TextFormatEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B576A2252771700350FFD /* TextFormatEncodingOptions.swift */; };
+		F4A07B2C1E4A3E620035678A /* test_messages_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A07B2A1E4A3E500035678A /* test_messages_proto3.pb.swift */; };
+		F4A07B2D1E4A3E630035678A /* test_messages_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A07B2A1E4A3E500035678A /* test_messages_proto3.pb.swift */; };
+		F4A07B2E1E4A3E640035678A /* test_messages_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A07B2A1E4A3E500035678A /* test_messages_proto3.pb.swift */; };
+		F4A1A8AD1E65E2EF0022E078 /* map_proto2_unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A1A8AB1E65E2EA0022E078 /* map_proto2_unittest.pb.swift */; };
+		F4A1A8AE1E65E2F00022E078 /* map_proto2_unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A1A8AB1E65E2EA0022E078 /* map_proto2_unittest.pb.swift */; };
+		F4A1A8AF1E65E2F10022E078 /* map_proto2_unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A1A8AB1E65E2EA0022E078 /* map_proto2_unittest.pb.swift */; };
+		F4C3A9711E96A08E006BB610 /* unittest_swift_oneof_all_required.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C3A96F1E969F79006BB610 /* unittest_swift_oneof_all_required.pb.swift */; };
+		F4C3A9721E96A08F006BB610 /* unittest_swift_oneof_all_required.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C3A96F1E969F79006BB610 /* unittest_swift_oneof_all_required.pb.swift */; };
+		F4C3A9731E96A090006BB610 /* unittest_swift_oneof_all_required.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C3A96F1E969F79006BB610 /* unittest_swift_oneof_all_required.pb.swift */; };
+		F4D315471DEC8117005D4A80 /* unittest_swift_extension2.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D315431DEC8110005D4A80 /* unittest_swift_extension2.pb.swift */; };
+		F4D315481DEC8117005D4A80 /* unittest_swift_extension3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D315441DEC8110005D4A80 /* unittest_swift_extension3.pb.swift */; };
+		F4D315491DEC811B005D4A80 /* unittest_swift_extension2.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D315431DEC8110005D4A80 /* unittest_swift_extension2.pb.swift */; };
+		F4D3154A1DEC811B005D4A80 /* unittest_swift_extension3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D315441DEC8110005D4A80 /* unittest_swift_extension3.pb.swift */; };
+		F4D3154B1DEC811C005D4A80 /* unittest_swift_extension2.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D315431DEC8110005D4A80 /* unittest_swift_extension2.pb.swift */; };
+		F4D3154C1DEC811C005D4A80 /* unittest_swift_extension3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D315441DEC8110005D4A80 /* unittest_swift_extension3.pb.swift */; };
+		F4D315541DECA0EA005D4A80 /* unittest_swift_extension4.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D315521DECA0E5005D4A80 /* unittest_swift_extension4.pb.swift */; };
+		F4D315551DECA0EA005D4A80 /* unittest_swift_extension4.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D315521DECA0E5005D4A80 /* unittest_swift_extension4.pb.swift */; };
+		F4D315561DECA0EB005D4A80 /* unittest_swift_extension4.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D315521DECA0E5005D4A80 /* unittest_swift_extension4.pb.swift */; };
+		F4E852B61EE9D83C00AE837E /* SelectiveVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E852B51EE9D83C00AE837E /* SelectiveVisitor.swift */; };
+		F4E852B71EE9D84800AE837E /* SelectiveVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E852B51EE9D83C00AE837E /* SelectiveVisitor.swift */; };
+		F4E852B81EE9D84900AE837E /* SelectiveVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E852B51EE9D83C00AE837E /* SelectiveVisitor.swift */; };
+		F4E852B91EE9D84A00AE837E /* SelectiveVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E852B51EE9D83C00AE837E /* SelectiveVisitor.swift */; };
+		F4EDCC2B22DF896500A1ECB7 /* DoubleParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EDCC2A22DF896500A1ECB7 /* DoubleParser.swift */; };
+		F4EDCC2C22DF896500A1ECB7 /* DoubleParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EDCC2A22DF896500A1ECB7 /* DoubleParser.swift */; };
+		F4EDCC2D22DF896500A1ECB7 /* DoubleParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EDCC2A22DF896500A1ECB7 /* DoubleParser.swift */; };
+		F4EDCC2E22DF896500A1ECB7 /* DoubleParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EDCC2A22DF896500A1ECB7 /* DoubleParser.swift */; };
+		F4F4F1181E5633E7006C6CAD /* Test_Naming.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F4F1161E5633E3006C6CAD /* Test_Naming.swift */; };
+		F4F4F1191E5633E8006C6CAD /* Test_Naming.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F4F1161E5633E3006C6CAD /* Test_Naming.swift */; };
+		F4F4F11A1E5633EA006C6CAD /* Test_Naming.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F4F1161E5633E3006C6CAD /* Test_Naming.swift */; };
+		F4F4F11B1E5C7556006C6CAD /* TimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC1CA0E1E54B81400CA8A26 /* TimeUtils.swift */; };
+		F4F4F11C1E5C7556006C6CAD /* TimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC1CA0E1E54B81400CA8A26 /* TimeUtils.swift */; };
+		F4F4F11D1E5C7557006C6CAD /* TimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC1CA0E1E54B81400CA8A26 /* TimeUtils.swift */; };
+		F4F4F11E1E5C7562006C6CAD /* MathUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC1CA0C1E54B80800CA8A26 /* MathUtils.swift */; };
+		F4F4F11F1E5C7563006C6CAD /* MathUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC1CA0C1E54B80800CA8A26 /* MathUtils.swift */; };
+		F4F4F1201E5C7565006C6CAD /* MathUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC1CA0C1E54B80800CA8A26 /* MathUtils.swift */; };
+		_LinkFileRef_Protobuf_via_ProtobufTestSuite /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Protobuf_macOS" /* SwiftProtobuf.framework */; };
+		__src_cc_ref_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration+Extensions.swift */; };
+		__src_cc_ref_Sources/Protobuf/Google_Protobuf_FieldMask_Extensions.swift /* Google_Protobuf_FieldMask+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_FieldMask_Extensions.swift /* Google_Protobuf_FieldMask+Extensions.swift */; };
+		__src_cc_ref_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct+Extensions.swift */; };
+		__src_cc_ref_Sources/Protobuf/Google_Protobuf_Timestamp_Extensions.swift /* Google_Protobuf_Timestamp+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Timestamp_Extensions.swift /* Google_Protobuf_Timestamp+Extensions.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufBinaryDecoding.swift /* BinaryDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* BinaryDecoder.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufBinaryTypes.swift /* Message+BinaryAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* Message+BinaryAdditions.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufHash.swift /* HashVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufHash.swift /* HashVisitor.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufJSONEncoding.swift /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufJSONEncoding.swift /* JSONEncoder.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufJSONTypes.swift /* Message+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufJSONTypes.swift /* Message+JSONAdditions.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufMessage.swift /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufMessage.swift /* Message.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufTypes.swift /* FieldTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufTypes.swift /* FieldTypes.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufUnknown.swift /* UnknownStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufUnknown.swift /* UnknownStorage.swift */; };
+		__src_cc_ref_Sources/Protobuf/api.pb.swift /* api.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/api.pb.swift /* api.pb.swift */; };
+		__src_cc_ref_Sources/Protobuf/duration.pb.swift /* duration.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/duration.pb.swift /* duration.pb.swift */; };
+		__src_cc_ref_Sources/Protobuf/empty.pb.swift /* empty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/empty.pb.swift /* empty.pb.swift */; };
+		__src_cc_ref_Sources/Protobuf/field_mask.pb.swift /* field_mask.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/field_mask.pb.swift /* field_mask.pb.swift */; };
+		__src_cc_ref_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */; };
+		__src_cc_ref_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */; };
+		__src_cc_ref_Sources/Protobuf/type.pb.swift /* type.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Api.swift /* Test_Api.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Api.swift /* Test_Api.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Conformance.swift /* Test_Conformance.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Conformance.swift /* Test_Conformance.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Duration.swift /* Test_Duration.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Duration.swift /* Test_Duration.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Empty.swift /* Test_Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Empty.swift /* Test_Empty.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Enum.swift /* Test_Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Enum.swift /* Test_Enum.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Extensions.swift /* Test_Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Extensions.swift /* Test_Extensions.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_ExtremeDefaultValues.swift /* Test_ExtremeDefaultValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_ExtremeDefaultValues.swift /* Test_ExtremeDefaultValues.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_FieldMask.swift /* Test_FieldMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_FieldMask.swift /* Test_FieldMask.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_FieldOrdering.swift /* Test_FieldOrdering.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_FieldOrdering.swift /* Test_FieldOrdering.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_JSON.swift /* Test_JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_JSON.swift /* Test_JSON.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_JSON_Conformance.swift /* Test_JSON_Conformance.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_JSON_Conformance.swift /* Test_JSON_Conformance.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_JSON_Group.swift /* Test_JSON_Group.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_JSON_Group.swift /* Test_JSON_Group.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Map.swift /* Test_Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Map.swift /* Test_Map.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Map_JSON.swift /* Test_Map_JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Map_JSON.swift /* Test_Map_JSON.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Packed.swift /* Test_Packed.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Packed.swift /* Test_Packed.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_ParsingMerge.swift /* Test_ParsingMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_ParsingMerge.swift /* Test_ParsingMerge.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_ReallyLargeTagNumber.swift /* Test_ReallyLargeTagNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_ReallyLargeTagNumber.swift /* Test_ReallyLargeTagNumber.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_RecursiveMap.swift /* Test_RecursiveMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_RecursiveMap.swift /* Test_RecursiveMap.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Required.swift /* Test_Required.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Required.swift /* Test_Required.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Reserved.swift /* Test_Reserved.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Reserved.swift /* Test_Reserved.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Struct.swift /* Test_Struct.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Struct.swift /* Test_Struct.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Timestamp.swift /* Test_Timestamp.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Timestamp.swift /* Test_Timestamp.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Type.swift /* Test_Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Type.swift /* Test_Type.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Unknown_proto2.swift /* Test_Unknown_proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto2.swift /* Test_Unknown_proto2.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Unknown_proto3.swift /* Test_Unknown_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto3.swift /* Test_Unknown_proto3.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/Test_Wrappers.swift /* Test_Wrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Wrappers.swift /* Test_Wrappers.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest.pb.swift /* unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest.pb.swift /* unittest.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_arena.pb.swift /* unittest_arena.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_arena.pb.swift /* unittest_arena.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_custom_options.pb.swift /* unittest_custom_options.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_custom_options.pb.swift /* unittest_custom_options.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_drop_unknown_fields.pb.swift /* unittest_drop_unknown_fields.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_drop_unknown_fields.pb.swift /* unittest_drop_unknown_fields.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_embed_optimize_for.pb.swift /* unittest_embed_optimize_for.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_embed_optimize_for.pb.swift /* unittest_embed_optimize_for.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_empty.pb.swift /* unittest_empty.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_empty.pb.swift /* unittest_empty.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_import.pb.swift /* unittest_import.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_import.pb.swift /* unittest_import.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_import_lite.pb.swift /* unittest_import_lite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_import_lite.pb.swift /* unittest_import_lite.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_import_public.pb.swift /* unittest_import_public.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_import_public.pb.swift /* unittest_import_public.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_import_public_lite.pb.swift /* unittest_import_public_lite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_import_public_lite.pb.swift /* unittest_import_public_lite.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_lite.pb.swift /* unittest_lite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_lite.pb.swift /* unittest_lite.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_lite_imports_nonlite.pb.swift /* unittest_lite_imports_nonlite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_lite_imports_nonlite.pb.swift /* unittest_lite_imports_nonlite.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_mset.pb.swift /* unittest_mset.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_mset.pb.swift /* unittest_mset.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_mset_wire_format.pb.swift /* unittest_mset_wire_format.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_mset_wire_format.pb.swift /* unittest_mset_wire_format.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_no_arena.pb.swift /* unittest_no_arena.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_arena.pb.swift /* unittest_no_arena.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_no_arena_import.pb.swift /* unittest_no_arena_import.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_arena_import.pb.swift /* unittest_no_arena_import.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_no_arena_lite.pb.swift /* unittest_no_arena_lite.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_arena_lite.pb.swift /* unittest_no_arena_lite.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_no_field_presence.pb.swift /* unittest_no_field_presence.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_field_presence.pb.swift /* unittest_no_field_presence.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_no_generic_services.pb.swift /* unittest_no_generic_services.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_no_generic_services.pb.swift /* unittest_no_generic_services.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_optimize_for.pb.swift /* unittest_optimize_for.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_optimize_for.pb.swift /* unittest_optimize_for.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_preserve_unknown_enum.pb.swift /* unittest_preserve_unknown_enum.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_preserve_unknown_enum.pb.swift /* unittest_preserve_unknown_enum.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_preserve_unknown_enum2.pb.swift /* unittest_preserve_unknown_enum2.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_preserve_unknown_enum2.pb.swift /* unittest_preserve_unknown_enum2.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_proto3.pb.swift /* unittest_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_proto3.pb.swift /* unittest_proto3.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_proto3_arena.pb.swift /* unittest_proto3_arena.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_proto3_arena.pb.swift /* unittest_proto3_arena.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_all_required_types.pb.swift /* unittest_swift_all_required_types.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_all_required_types.pb.swift /* unittest_swift_all_required_types.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_cycle.pb.swift /* unittest_swift_cycle.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_cycle.pb.swift /* unittest_swift_cycle.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_enum.pb.swift /* unittest_swift_enum.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_enum.pb.swift /* unittest_swift_enum.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_enum_optional_default.pb.swift /* unittest_swift_enum_optional_default.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_enum_optional_default.pb.swift /* unittest_swift_enum_optional_default.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_extension.pb.swift /* unittest_swift_extension.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_extension.pb.swift /* unittest_swift_extension.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_fieldorder.pb.swift /* unittest_swift_fieldorder.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_fieldorder.pb.swift /* unittest_swift_fieldorder.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_groups.pb.swift /* unittest_swift_groups.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_groups.pb.swift /* unittest_swift_groups.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_naming.pb.swift /* unittest_swift_naming.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_naming.pb.swift /* unittest_swift_naming.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_performance.pb.swift /* unittest_swift_performance.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_performance.pb.swift /* unittest_swift_performance.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_reserved.pb.swift /* unittest_swift_reserved.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_reserved.pb.swift /* unittest_swift_reserved.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_runtime_proto2.pb.swift /* unittest_swift_runtime_proto2.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_runtime_proto2.pb.swift /* unittest_swift_runtime_proto2.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_runtime_proto3.pb.swift /* unittest_swift_runtime_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_runtime_proto3.pb.swift /* unittest_swift_runtime_proto3.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_swift_startup.pb.swift /* unittest_swift_startup.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_startup.pb.swift /* unittest_swift_startup.pb.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/unittest_well_known_types.pb.swift /* unittest_well_known_types.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_well_known_types.pb.swift /* unittest_well_known_types.pb.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		9C8CDA181D7A288E00E207CA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = __RootObject_ /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BD12FD351D767BA0001815C7;
+			remoteInfo = Protobuf_iOS;
+		};
+		9CAEA5251D25B35600EB832A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = __RootObject_ /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "______Target_Protobuf";
+			remoteInfo = Protobuf;
+		};
+		F44F93A51DAEA7C500BC5B85 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = __RootObject_ /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F44F936E1DAEA53900BC5B85;
+			remoteInfo = SwiftProtobuf_tvOS;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		8DC1CA0C1E54B80800CA8A26 /* MathUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MathUtils.swift; sourceTree = "<group>"; };
+		8DC1CA0E1E54B81400CA8A26 /* TimeUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeUtils.swift; sourceTree = "<group>"; };
+		9C0B366A1E5FAB910094E128 /* JSONMapEncodingVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONMapEncodingVisitor.swift; sourceTree = "<group>"; };
+		9C4178601E809DA2007830C3 /* ExtensionMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionMap.swift; sourceTree = "<group>"; };
+		9C5890A51DFF5EC8001CFC34 /* Test_TextFormat_proto2_extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_proto2_extensions.swift; sourceTree = "<group>"; };
+		9C60CBE71DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_Map_proto3.swift; sourceTree = "<group>"; };
+		9C60CBEB1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_proto2.swift; sourceTree = "<group>"; };
+		9C667A8E1E4C203D008B974F /* JSONDecodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONDecodingError.swift; sourceTree = "<group>"; };
+		9C667A8F1E4C203D008B974F /* BinaryDecodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryDecodingError.swift; sourceTree = "<group>"; };
+		9C667A901E4C203D008B974F /* TextFormatDecodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFormatDecodingError.swift; sourceTree = "<group>"; };
+		9C7254651E5F9B1600486C98 /* Test_TextFormat_Unknown.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_Unknown.swift; sourceTree = "<group>"; };
+		9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Visitor.swift; sourceTree = "<group>"; };
+		9C75F8841DDD3045005CCFF2 /* SimpleExtensionMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleExtensionMap.swift; sourceTree = "<group>"; };
+		9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionFieldValueSet.swift; sourceTree = "<group>"; };
+		9C75F88E1DDD3108005CCFF2 /* ExtensibleMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensibleMessage.swift; sourceTree = "<group>"; };
+		9C75F8931DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryEncodingVisitor.swift; sourceTree = "<group>"; };
+		9C75F89D1DDD3FA3005CCFF2 /* JSONDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONDecoder.swift; sourceTree = "<group>"; };
+		9C75F8A21DDD44A1005CCFF2 /* ProtobufMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtobufMap.swift; sourceTree = "<group>"; };
+		9C84E48C1E5E3ABD00513BE0 /* BinaryEncodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryEncodingError.swift; sourceTree = "<group>"; };
+		9C84E48D1E5E3ABD00513BE0 /* JSONEncodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONEncodingError.swift; sourceTree = "<group>"; };
+		9CA424411E286D4E00C0E5B4 /* StringUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringUtils.swift; sourceTree = "<group>"; };
+		9CC8CAA81EC512A0008EF45F /* generated_swift_names_enum_cases.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = generated_swift_names_enum_cases.pb.swift; sourceTree = "<group>"; };
+		9CC8CAA91EC512A0008EF45F /* generated_swift_names_enums.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = generated_swift_names_enums.pb.swift; sourceTree = "<group>"; };
+		9CC8CAAA1EC512A0008EF45F /* generated_swift_names_fields.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = generated_swift_names_fields.pb.swift; sourceTree = "<group>"; };
+		9CC8CAAB1EC512A0008EF45F /* generated_swift_names_messages.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = generated_swift_names_messages.pb.swift; sourceTree = "<group>"; };
+		9CCD5F921E008203002D1940 /* Test_TextFormat_WKT_proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_WKT_proto3.swift; sourceTree = "<group>"; };
+		9CE9CF361E32C9F8004FBED6 /* JSONScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONScanner.swift; sourceTree = "<group>"; };
+		9CEB0D671DF5E934002D80F0 /* TextFormatEncodingVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFormatEncodingVisitor.swift; sourceTree = "<group>"; };
+		9CEB0D6B1DF5F921002D80F0 /* TextFormatScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFormatScanner.swift; sourceTree = "<group>"; };
+		AA05BF491DAEB7E400619042 /* WireFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireFormat.swift; sourceTree = "<group>"; };
+		AA05BF4E1DAEB7E800619042 /* FieldTag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FieldTag.swift; sourceTree = "<group>"; };
+		AA28A4A51DA30E5900C866D9 /* ZigZag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZigZag.swift; sourceTree = "<group>"; };
+		AA28A4A81DA40B0900C866D9 /* Varint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Varint.swift; sourceTree = "<group>"; };
+		AA28A4AB1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryEncodingSizeVisitor.swift; sourceTree = "<group>"; };
+		AA3640901E60D043000C3CF4 /* struct.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = struct.pb.swift; sourceTree = "<group>"; };
+		AA3640951E60EBB0000C3CF4 /* Test_Merge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_Merge.swift; sourceTree = "<group>"; };
+		AA6CF6F01DB6D1F8007DF26B /* Test_Enum_Proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_Enum_Proto2.swift; sourceTree = "<group>"; };
+		AA78AD351E84C5B4001C43F9 /* Message+AnyAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Message+AnyAdditions.swift"; sourceTree = "<group>"; };
+		AA86F6F91E0A0F0B006CC38A /* JSONEncodingVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONEncodingVisitor.swift; sourceTree = "<group>"; };
+		AAABA40A1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtobufAPIVersionCheck.swift; sourceTree = "<group>"; };
+		AAB979F41E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_ListValue+Extensions.swift"; sourceTree = "<group>"; };
+		AAE0F4DE1E6A3886005240E0 /* Test_EnumWithAliases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_EnumWithAliases.swift; sourceTree = "<group>"; };
+		AAE0F4E21E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Value+Extensions.swift"; sourceTree = "<group>"; };
+		AAEA521F1DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Message+UInt8ArrayHelpers.swift"; sourceTree = "<group>"; };
+		AAEA52711DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Wrappers+Extensions.swift"; sourceTree = "<group>"; };
+		AAEA52731DA80DEA003F318F /* wrappers.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = wrappers.pb.swift; sourceTree = "<group>"; };
+		AAF2ED391DEF3FBC007B510F /* NameMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NameMap.swift; sourceTree = "<group>"; };
+		AAF2ED3E1DEF4D94007B510F /* ProtoNameProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtoNameProviding.swift; sourceTree = "<group>"; };
+		BCCA0E661DB1210E00957D74 /* TextFormatDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFormatDecoder.swift; sourceTree = "<group>"; };
+		BCCA0E671DB1210E00957D74 /* TextFormatEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFormatEncoder.swift; sourceTree = "<group>"; };
+		BCCA0E681DB1210E00957D74 /* Message+TextFormatAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Message+TextFormatAdditions.swift"; sourceTree = "<group>"; };
+		BCCA0E751DB123F800957D74 /* Test_TextFormat_proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_proto3.swift; sourceTree = "<group>"; };
+		DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_JSON_Array.swift; sourceTree = "<group>"; };
+		DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "Message+JSONArrayAdditions.swift"; sourceTree = "<group>"; tabWidth = 2; };
+		E7038A23224D7F1000B68775 /* Data+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
+		F40D33E82017ECD300ABAF0F /* unittest_swift_enum_proto3.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_enum_proto3.pb.swift; sourceTree = "<group>"; };
+		F411FE941EDDD6AA001AE6B2 /* BinaryDecodingOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryDecodingOptions.swift; sourceTree = "<group>"; };
+		F411FEAA1EDDDC5D001AE6B2 /* Test_BinaryDecodingOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_BinaryDecodingOptions.swift; sourceTree = "<group>"; };
+		F4151F641EF3193F00EEA00B /* Test_SimpleExtensionMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_SimpleExtensionMap.swift; sourceTree = "<group>"; };
+		F4151F701EFAB83400EEA00B /* BinaryDelimited.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryDelimited.swift; sourceTree = "<group>"; };
+		F4151F751EFAD85600EEA00B /* Test_BinaryDelimited.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_BinaryDelimited.swift; sourceTree = "<group>"; };
+		F41BA3FB1E76F635004F6E95 /* Google_Protobuf_Any+Registry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Any+Registry.swift"; sourceTree = "<group>"; };
+		F41BA4121E79BDCA004F6E95 /* Google_Protobuf_Any+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Any+Extensions.swift"; sourceTree = "<group>"; };
+		F41BA4171E79C568004F6E95 /* AnyUnpackError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyUnpackError.swift; sourceTree = "<group>"; };
+		F41BA43F1E7AE4AC004F6E95 /* any.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = any.pb.swift; sourceTree = "<group>"; };
+		F41BA4411E7AE53C004F6E95 /* AnyMessageStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyMessageStorage.swift; sourceTree = "<group>"; };
+		F44F936F1DAEA53900BC5B85 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftProtobuf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F44F939F1DAEA7C500BC5B85 /* SwiftProtobufTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftProtobufTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F44F93FE1DAEB13F00BC5B85 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftProtobuf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_BasicFields_Access_Proto2.swift; sourceTree = "<group>"; };
+		F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_BasicFields_Access_Proto3.swift; sourceTree = "<group>"; };
+		F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_OneofFields_Access_Proto2.swift; sourceTree = "<group>"; };
+		F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_OneofFields_Access_Proto3.swift; sourceTree = "<group>"; };
+		F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_MapFields_Access_Proto2.swift; sourceTree = "<group>"; };
+		F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_MapFields_Access_Proto3.swift; sourceTree = "<group>"; };
+		F451074423A288E400488257 /* UnsafeRawPointer+Shims.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UnsafeRawPointer+Shims.swift"; sourceTree = "<group>"; };
+		F451074523A288E400488257 /* UnsafeBufferPointer+Shims.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UnsafeBufferPointer+Shims.swift"; sourceTree = "<group>"; };
+		F451075723A2B9B500488257 /* Data+TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+TestHelpers.swift"; sourceTree = "<group>"; };
+		F4539D241E688B000076251F /* Test_GroupWithGroups.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_GroupWithGroups.swift; sourceTree = "<group>"; };
+		F4539D291E6F5DC70076251F /* CustomJSONCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomJSONCodable.swift; sourceTree = "<group>"; };
+		F4584D391ECA4FB400803AB6 /* unittest_swift_oneof_merging.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_oneof_merging.pb.swift; sourceTree = "<group>"; };
+		F4584DB21EDDC9D400803AB6 /* Test_JSONDecodingOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_JSONDecodingOptions.swift; sourceTree = "<group>"; };
+		F4584DB71EDDCAD600803AB6 /* JSONDecodingOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONDecodingOptions.swift; sourceTree = "<group>"; };
+		F45D73FB1EE994C700E0A231 /* Test_MessageSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_MessageSet.swift; sourceTree = "<group>"; };
+		F4618B552154151700E5FABA /* JSONEncodingOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONEncodingOptions.swift; sourceTree = "<group>"; };
+		F4618B632154245500E5FABA /* Test_JSONEncodingOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_JSONEncodingOptions.swift; sourceTree = "<group>"; };
+		F47138951E4E56AC00C8492C /* Internal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Internal.swift; sourceTree = "<group>"; };
+		F47C42B42437A3C700C08579 /* unittest_proto3_optional.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_proto3_optional.pb.swift; sourceTree = "<group>"; };
+		F47C42C12437A73000C08579 /* Test_AllTypes_Proto3_Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_AllTypes_Proto3_Optional.swift; sourceTree = "<group>"; };
+		F47CF9A023E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_naming_number_prefix.pb.swift; sourceTree = "<group>"; };
+		F482B6771E856D1700A25EF8 /* unittest_swift_reserved_ext.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_reserved_ext.pb.swift; sourceTree = "<group>"; };
+		F482B6911E857BBC00A25EF8 /* unittest_swift_naming_no_prefix.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_naming_no_prefix.pb.swift; sourceTree = "<group>"; };
+		F482B6B21E89940E00A25EF8 /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
+		F48769F723020B7D00D44224 /* descriptor.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = descriptor.pb.swift; sourceTree = "<group>"; };
+		F49B576A2252771700350FFD /* TextFormatEncodingOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFormatEncodingOptions.swift; sourceTree = "<group>"; };
+		F4A07B2A1E4A3E500035678A /* test_messages_proto3.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = test_messages_proto3.pb.swift; sourceTree = "<group>"; };
+		F4A1A8AB1E65E2EA0022E078 /* map_proto2_unittest.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = map_proto2_unittest.pb.swift; sourceTree = "<group>"; };
+		F4C3A96F1E969F79006BB610 /* unittest_swift_oneof_all_required.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_oneof_all_required.pb.swift; sourceTree = "<group>"; };
+		F4D315431DEC8110005D4A80 /* unittest_swift_extension2.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_extension2.pb.swift; sourceTree = "<group>"; };
+		F4D315441DEC8110005D4A80 /* unittest_swift_extension3.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_extension3.pb.swift; sourceTree = "<group>"; };
+		F4D315521DECA0E5005D4A80 /* unittest_swift_extension4.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_extension4.pb.swift; sourceTree = "<group>"; };
+		F4E852B51EE9D83C00AE837E /* SelectiveVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectiveVisitor.swift; sourceTree = "<group>"; };
+		F4EDCC2A22DF896500A1ECB7 /* DoubleParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DoubleParser.swift; sourceTree = "<group>"; };
+		F4F4F1161E5633E3006C6CAD /* Test_Naming.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_Naming.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Package.swift /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		__PBXFileRef_ProtobufTestSuite_Info.plist /* ProtobufTestSuite_Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = ProtobufTestSuite_Info.plist; path = SwiftProtobuf.xcodeproj/ProtobufTestSuite_Info.plist; sourceTree = SOURCE_ROOT; };
+		__PBXFileRef_Protobuf_Info.plist /* Protobuf_Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Protobuf_Info.plist; path = SwiftProtobuf.xcodeproj/Protobuf_Info.plist; sourceTree = SOURCE_ROOT; };
+		__PBXFileRef_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Duration+Extensions.swift"; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/Google_Protobuf_FieldMask_Extensions.swift /* Google_Protobuf_FieldMask+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_FieldMask+Extensions.swift"; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Struct+Extensions.swift"; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/Google_Protobuf_Timestamp_Extensions.swift /* Google_Protobuf_Timestamp+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Timestamp+Extensions.swift"; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* BinaryDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryDecoder.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryEncoder.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* Message+BinaryAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+BinaryAdditions.swift"; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enum.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionFields.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageExtension.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufHash.swift /* HashVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashVisitor.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufJSONEncoding.swift /* JSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncoder.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufJSONTypes.swift /* Message+JSONAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+JSONAdditions.swift"; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufMessage.swift /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufTypes.swift /* FieldTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldTypes.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufUnknown.swift /* UnknownStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownStorage.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/api.pb.swift /* api.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = api.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/duration.pb.swift /* duration.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = duration.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/empty.pb.swift /* empty.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = empty.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/field_mask.pb.swift /* field_mask.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = field_mask.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = source_context.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = timestamp.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = type.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_AllTypes.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_AllTypes_Proto3.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Any.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Api.swift /* Test_Api.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Api.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Conformance.swift /* Test_Conformance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Conformance.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Duration.swift /* Test_Duration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Duration.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Empty.swift /* Test_Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Empty.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Enum.swift /* Test_Enum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Enum.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Extensions.swift /* Test_Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Extensions.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_ExtremeDefaultValues.swift /* Test_ExtremeDefaultValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_ExtremeDefaultValues.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_FieldMask.swift /* Test_FieldMask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_FieldMask.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_FieldOrdering.swift /* Test_FieldOrdering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_FieldOrdering.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_JSON.swift /* Test_JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_JSON.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_JSON_Conformance.swift /* Test_JSON_Conformance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_JSON_Conformance.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_JSON_Group.swift /* Test_JSON_Group.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_JSON_Group.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Map.swift /* Test_Map.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Map.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Map_JSON.swift /* Test_Map_JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Map_JSON.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Packed.swift /* Test_Packed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Packed.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_ParsingMerge.swift /* Test_ParsingMerge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_ParsingMerge.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_ReallyLargeTagNumber.swift /* Test_ReallyLargeTagNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_ReallyLargeTagNumber.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_RecursiveMap.swift /* Test_RecursiveMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_RecursiveMap.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Required.swift /* Test_Required.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Required.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Reserved.swift /* Test_Reserved.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Reserved.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Struct.swift /* Test_Struct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Struct.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Timestamp.swift /* Test_Timestamp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Timestamp.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Type.swift /* Test_Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Type.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto2.swift /* Test_Unknown_proto2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Unknown_proto2.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto3.swift /* Test_Unknown_proto3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Unknown_proto3.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Test_Wrappers.swift /* Test_Wrappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Wrappers.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = any_test.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = conformance.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = map_unittest.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest.pb.swift /* unittest.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_arena.pb.swift /* unittest_arena.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_arena.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_custom_options.pb.swift /* unittest_custom_options.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_custom_options.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_drop_unknown_fields.pb.swift /* unittest_drop_unknown_fields.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_drop_unknown_fields.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_embed_optimize_for.pb.swift /* unittest_embed_optimize_for.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_embed_optimize_for.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_empty.pb.swift /* unittest_empty.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_empty.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_import.pb.swift /* unittest_import.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_import.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_import_lite.pb.swift /* unittest_import_lite.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_import_lite.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_import_public.pb.swift /* unittest_import_public.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_import_public.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_import_public_lite.pb.swift /* unittest_import_public_lite.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_import_public_lite.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_lite.pb.swift /* unittest_lite.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_lite.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_lite_imports_nonlite.pb.swift /* unittest_lite_imports_nonlite.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_lite_imports_nonlite.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_mset.pb.swift /* unittest_mset.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_mset.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_mset_wire_format.pb.swift /* unittest_mset_wire_format.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_mset_wire_format.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_no_arena.pb.swift /* unittest_no_arena.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_no_arena.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_no_arena_import.pb.swift /* unittest_no_arena_import.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_no_arena_import.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_no_arena_lite.pb.swift /* unittest_no_arena_lite.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_no_arena_lite.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_no_field_presence.pb.swift /* unittest_no_field_presence.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_no_field_presence.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_no_generic_services.pb.swift /* unittest_no_generic_services.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_no_generic_services.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_optimize_for.pb.swift /* unittest_optimize_for.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_optimize_for.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_preserve_unknown_enum.pb.swift /* unittest_preserve_unknown_enum.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_preserve_unknown_enum.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_preserve_unknown_enum2.pb.swift /* unittest_preserve_unknown_enum2.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_preserve_unknown_enum2.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_proto3.pb.swift /* unittest_proto3.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_proto3.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_proto3_arena.pb.swift /* unittest_proto3_arena.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_proto3_arena.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_all_required_types.pb.swift /* unittest_swift_all_required_types.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_all_required_types.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_cycle.pb.swift /* unittest_swift_cycle.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_cycle.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_enum.pb.swift /* unittest_swift_enum.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_enum.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_enum_optional_default.pb.swift /* unittest_swift_enum_optional_default.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_enum_optional_default.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_extension.pb.swift /* unittest_swift_extension.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_extension.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_fieldorder.pb.swift /* unittest_swift_fieldorder.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_fieldorder.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_groups.pb.swift /* unittest_swift_groups.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_groups.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_naming.pb.swift /* unittest_swift_naming.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_naming.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_performance.pb.swift /* unittest_swift_performance.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_performance.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_reserved.pb.swift /* unittest_swift_reserved.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_reserved.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_runtime_proto2.pb.swift /* unittest_swift_runtime_proto2.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_runtime_proto2.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_runtime_proto3.pb.swift /* unittest_swift_runtime_proto3.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_runtime_proto3.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_swift_startup.pb.swift /* unittest_swift_startup.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_swift_startup.pb.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/unittest_well_known_types.pb.swift /* unittest_well_known_types.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = unittest_well_known_types.pb.swift; sourceTree = "<group>"; };
+		"_____Product_ProtobufTestSuite_iOS" /* SwiftProtobufTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftProtobufTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"_____Product_ProtobufTestSuite_macOS" /* SwiftProtobufTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = SwiftProtobufTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"_____Product_Protobuf_iOS" /* SwiftProtobuf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftProtobuf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"_____Product_Protobuf_macOS" /* SwiftProtobuf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SwiftProtobuf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9C8CDA0F1D7A288E00E207CA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9C8CDA171D7A288E00E207CA /* SwiftProtobuf.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F44F939C1DAEA7C500BC5B85 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F44F93A41DAEA7C500BC5B85 /* SwiftProtobuf.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		"___LinkPhase_ProtobufTestSuite" /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				_LinkFileRef_Protobuf_via_ProtobufTestSuite /* SwiftProtobuf.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		"___RootGroup_" = {
+			isa = PBXGroup;
+			children = (
+				__PBXFileRef_Package.swift /* Package.swift */,
+				"_____Sources_" /* Sources */,
+				"_______Tests_" /* Tests */,
+				"_____Configs_" /* Resources */,
+				"____Products_" /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		"____Products_" /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"_____Product_Protobuf_macOS" /* SwiftProtobuf.framework */,
+				"_____Product_ProtobufTestSuite_macOS" /* SwiftProtobufTests.xctest */,
+				"_____Product_Protobuf_iOS" /* SwiftProtobuf.framework */,
+				"_____Product_ProtobufTestSuite_iOS" /* SwiftProtobufTests.xctest */,
+				F44F936F1DAEA53900BC5B85 /* SwiftProtobuf.framework */,
+				F44F939F1DAEA7C500BC5B85 /* SwiftProtobufTests.xctest */,
+				F44F93FE1DAEB13F00BC5B85 /* SwiftProtobuf.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		"_____Configs_" /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				__PBXFileRef_Protobuf_Info.plist /* Protobuf_Info.plist */,
+				__PBXFileRef_ProtobufTestSuite_Info.plist /* ProtobufTestSuite_Info.plist */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		"_____Sources_" /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				"_______Group_Protobuf" /* SwiftProtobuf */,
+			);
+			name = Sources;
+			sourceTree = "<group>";
+		};
+		"_______Group_Protobuf" /* SwiftProtobuf */ = {
+			isa = PBXGroup;
+			children = (
+				F41BA43F1E7AE4AC004F6E95 /* any.pb.swift */,
+				F41BA4411E7AE53C004F6E95 /* AnyMessageStorage.swift */,
+				F41BA4171E79C568004F6E95 /* AnyUnpackError.swift */,
+				__PBXFileRef_Sources/Protobuf/api.pb.swift /* api.pb.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* BinaryDecoder.swift */,
+				9C667A8F1E4C203D008B974F /* BinaryDecodingError.swift */,
+				F411FE941EDDD6AA001AE6B2 /* BinaryDecodingOptions.swift */,
+				F4151F701EFAB83400EEA00B /* BinaryDelimited.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift */,
+				9C84E48C1E5E3ABD00513BE0 /* BinaryEncodingError.swift */,
+				AA28A4AB1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift */,
+				9C75F8931DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift */,
+				F4539D291E6F5DC70076251F /* CustomJSONCodable.swift */,
+				E7038A23224D7F1000B68775 /* Data+Extensions.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */,
+				F48769F723020B7D00D44224 /* descriptor.pb.swift */,
+				F4EDCC2A22DF896500A1ECB7 /* DoubleParser.swift */,
+				__PBXFileRef_Sources/Protobuf/duration.pb.swift /* duration.pb.swift */,
+				__PBXFileRef_Sources/Protobuf/empty.pb.swift /* empty.pb.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */,
+				9C75F88E1DDD3108005CCFF2 /* ExtensibleMessage.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */,
+				9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */,
+				9C4178601E809DA2007830C3 /* ExtensionMap.swift */,
+				__PBXFileRef_Sources/Protobuf/field_mask.pb.swift /* field_mask.pb.swift */,
+				AA05BF4E1DAEB7E800619042 /* FieldTag.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufTypes.swift /* FieldTypes.swift */,
+				F41BA4121E79BDCA004F6E95 /* Google_Protobuf_Any+Extensions.swift */,
+				F41BA3FB1E76F635004F6E95 /* Google_Protobuf_Any+Registry.swift */,
+				__PBXFileRef_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration+Extensions.swift */,
+				__PBXFileRef_Sources/Protobuf/Google_Protobuf_FieldMask_Extensions.swift /* Google_Protobuf_FieldMask+Extensions.swift */,
+				AAB979F41E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift */,
+				__PBXFileRef_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct+Extensions.swift */,
+				__PBXFileRef_Sources/Protobuf/Google_Protobuf_Timestamp_Extensions.swift /* Google_Protobuf_Timestamp+Extensions.swift */,
+				AAE0F4E21E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift */,
+				AAEA52711DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufHash.swift /* HashVisitor.swift */,
+				F47138951E4E56AC00C8492C /* Internal.swift */,
+				9C75F89D1DDD3FA3005CCFF2 /* JSONDecoder.swift */,
+				9C667A8E1E4C203D008B974F /* JSONDecodingError.swift */,
+				F4584DB71EDDCAD600803AB6 /* JSONDecodingOptions.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufJSONEncoding.swift /* JSONEncoder.swift */,
+				9C84E48D1E5E3ABD00513BE0 /* JSONEncodingError.swift */,
+				F4618B552154151700E5FABA /* JSONEncodingOptions.swift */,
+				AA86F6F91E0A0F0B006CC38A /* JSONEncodingVisitor.swift */,
+				9C0B366A1E5FAB910094E128 /* JSONMapEncodingVisitor.swift */,
+				9CE9CF361E32C9F8004FBED6 /* JSONScanner.swift */,
+				8DC1CA0C1E54B80800CA8A26 /* MathUtils.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufMessage.swift /* Message.swift */,
+				AA78AD351E84C5B4001C43F9 /* Message+AnyAdditions.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* Message+BinaryAdditions.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufJSONTypes.swift /* Message+JSONAdditions.swift */,
+				DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */,
+				BCCA0E681DB1210E00957D74 /* Message+TextFormatAdditions.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift */,
+				AAF2ED391DEF3FBC007B510F /* NameMap.swift */,
+				AAABA40A1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift */,
+				9C75F8A21DDD44A1005CCFF2 /* ProtobufMap.swift */,
+				AAF2ED3E1DEF4D94007B510F /* ProtoNameProviding.swift */,
+				F4E852B51EE9D83C00AE837E /* SelectiveVisitor.swift */,
+				9C75F8841DDD3045005CCFF2 /* SimpleExtensionMap.swift */,
+				__PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */,
+				9CA424411E286D4E00C0E5B4 /* StringUtils.swift */,
+				AA3640901E60D043000C3CF4 /* struct.pb.swift */,
+				BCCA0E661DB1210E00957D74 /* TextFormatDecoder.swift */,
+				9C667A901E4C203D008B974F /* TextFormatDecodingError.swift */,
+				BCCA0E671DB1210E00957D74 /* TextFormatEncoder.swift */,
+				F49B576A2252771700350FFD /* TextFormatEncodingOptions.swift */,
+				9CEB0D671DF5E934002D80F0 /* TextFormatEncodingVisitor.swift */,
+				9CEB0D6B1DF5F921002D80F0 /* TextFormatScanner.swift */,
+				__PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */,
+				8DC1CA0E1E54B81400CA8A26 /* TimeUtils.swift */,
+				__PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufUnknown.swift /* UnknownStorage.swift */,
+				F451074523A288E400488257 /* UnsafeBufferPointer+Shims.swift */,
+				F451074423A288E400488257 /* UnsafeRawPointer+Shims.swift */,
+				AA28A4A81DA40B0900C866D9 /* Varint.swift */,
+				F482B6B21E89940E00A25EF8 /* Version.swift */,
+				9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */,
+				AA05BF491DAEB7E400619042 /* WireFormat.swift */,
+				AAEA52731DA80DEA003F318F /* wrappers.pb.swift */,
+				AA28A4A51DA30E5900C866D9 /* ZigZag.swift */,
+			);
+			name = SwiftProtobuf;
+			path = Sources/SwiftProtobuf;
+			sourceTree = "<group>";
+		};
+		"_______Group_ProtobufTestSuite" /* SwiftProtobufTests */ = {
+			isa = PBXGroup;
+			children = (
+				__PBXFileRef_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift */,
+				F451075723A2B9B500488257 /* Data+TestHelpers.swift */,
+				9CC8CAA81EC512A0008EF45F /* generated_swift_names_enum_cases.pb.swift */,
+				9CC8CAA91EC512A0008EF45F /* generated_swift_names_enums.pb.swift */,
+				9CC8CAAA1EC512A0008EF45F /* generated_swift_names_fields.pb.swift */,
+				9CC8CAAB1EC512A0008EF45F /* generated_swift_names_messages.pb.swift */,
+				F4A1A8AB1E65E2EA0022E078 /* map_proto2_unittest.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */,
+				AAEA521F1DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift */,
+				F47C42C12437A73000C08579 /* Test_AllTypes_Proto3_Optional.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Api.swift /* Test_Api.swift */,
+				F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */,
+				F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */,
+				F411FEAA1EDDDC5D001AE6B2 /* Test_BinaryDecodingOptions.swift */,
+				F4151F751EFAD85600EEA00B /* Test_BinaryDelimited.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Conformance.swift /* Test_Conformance.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Duration.swift /* Test_Duration.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Empty.swift /* Test_Empty.swift */,
+				AA6CF6F01DB6D1F8007DF26B /* Test_Enum_Proto2.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Enum.swift /* Test_Enum.swift */,
+				AAE0F4DE1E6A3886005240E0 /* Test_EnumWithAliases.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Extensions.swift /* Test_Extensions.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_ExtremeDefaultValues.swift /* Test_ExtremeDefaultValues.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_FieldMask.swift /* Test_FieldMask.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_FieldOrdering.swift /* Test_FieldOrdering.swift */,
+				F4539D241E688B000076251F /* Test_GroupWithGroups.swift */,
+				DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_JSON_Conformance.swift /* Test_JSON_Conformance.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_JSON_Group.swift /* Test_JSON_Group.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_JSON.swift /* Test_JSON.swift */,
+				F4584DB21EDDC9D400803AB6 /* Test_JSONDecodingOptions.swift */,
+				F4618B632154245500E5FABA /* Test_JSONEncodingOptions.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Map_JSON.swift /* Test_Map_JSON.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Map.swift /* Test_Map.swift */,
+				F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */,
+				F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */,
+				AA3640951E60EBB0000C3CF4 /* Test_Merge.swift */,
+				F4A07B2A1E4A3E500035678A /* test_messages_proto3.pb.swift */,
+				F45D73FB1EE994C700E0A231 /* Test_MessageSet.swift */,
+				F4F4F1161E5633E3006C6CAD /* Test_Naming.swift */,
+				F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */,
+				F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Packed.swift /* Test_Packed.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_ParsingMerge.swift /* Test_ParsingMerge.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_ReallyLargeTagNumber.swift /* Test_ReallyLargeTagNumber.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_RecursiveMap.swift /* Test_RecursiveMap.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Required.swift /* Test_Required.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Reserved.swift /* Test_Reserved.swift */,
+				F4151F641EF3193F00EEA00B /* Test_SimpleExtensionMap.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Struct.swift /* Test_Struct.swift */,
+				9C60CBE71DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift */,
+				9C5890A51DFF5EC8001CFC34 /* Test_TextFormat_proto2_extensions.swift */,
+				9C60CBEB1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift */,
+				BCCA0E751DB123F800957D74 /* Test_TextFormat_proto3.swift */,
+				9C7254651E5F9B1600486C98 /* Test_TextFormat_Unknown.swift */,
+				9CCD5F921E008203002D1940 /* Test_TextFormat_WKT_proto3.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Timestamp.swift /* Test_Timestamp.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Type.swift /* Test_Type.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto2.swift /* Test_Unknown_proto2.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto3.swift /* Test_Unknown_proto3.swift */,
+				__PBXFileRef_Tests/ProtobufTests/Test_Wrappers.swift /* Test_Wrappers.swift */,
+				__PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_arena.pb.swift /* unittest_arena.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_custom_options.pb.swift /* unittest_custom_options.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_drop_unknown_fields.pb.swift /* unittest_drop_unknown_fields.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_embed_optimize_for.pb.swift /* unittest_embed_optimize_for.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_empty.pb.swift /* unittest_empty.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_import_lite.pb.swift /* unittest_import_lite.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_import_public_lite.pb.swift /* unittest_import_public_lite.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_import_public.pb.swift /* unittest_import_public.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_import.pb.swift /* unittest_import.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_lite_imports_nonlite.pb.swift /* unittest_lite_imports_nonlite.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_lite.pb.swift /* unittest_lite.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_mset_wire_format.pb.swift /* unittest_mset_wire_format.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_mset.pb.swift /* unittest_mset.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_no_arena_import.pb.swift /* unittest_no_arena_import.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_no_arena_lite.pb.swift /* unittest_no_arena_lite.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_no_arena.pb.swift /* unittest_no_arena.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_no_field_presence.pb.swift /* unittest_no_field_presence.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_no_generic_services.pb.swift /* unittest_no_generic_services.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_optimize_for.pb.swift /* unittest_optimize_for.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_preserve_unknown_enum.pb.swift /* unittest_preserve_unknown_enum.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_preserve_unknown_enum2.pb.swift /* unittest_preserve_unknown_enum2.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_proto3_arena.pb.swift /* unittest_proto3_arena.pb.swift */,
+				F47C42B42437A3C700C08579 /* unittest_proto3_optional.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_proto3.pb.swift /* unittest_proto3.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_all_required_types.pb.swift /* unittest_swift_all_required_types.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_cycle.pb.swift /* unittest_swift_cycle.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_enum_optional_default.pb.swift /* unittest_swift_enum_optional_default.pb.swift */,
+				F40D33E82017ECD300ABAF0F /* unittest_swift_enum_proto3.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_enum.pb.swift /* unittest_swift_enum.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_extension.pb.swift /* unittest_swift_extension.pb.swift */,
+				F4D315431DEC8110005D4A80 /* unittest_swift_extension2.pb.swift */,
+				F4D315441DEC8110005D4A80 /* unittest_swift_extension3.pb.swift */,
+				F4D315521DECA0E5005D4A80 /* unittest_swift_extension4.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_fieldorder.pb.swift /* unittest_swift_fieldorder.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_groups.pb.swift /* unittest_swift_groups.pb.swift */,
+				F482B6911E857BBC00A25EF8 /* unittest_swift_naming_no_prefix.pb.swift */,
+				F47CF9A023E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_naming.pb.swift /* unittest_swift_naming.pb.swift */,
+				F4C3A96F1E969F79006BB610 /* unittest_swift_oneof_all_required.pb.swift */,
+				F4584D391ECA4FB400803AB6 /* unittest_swift_oneof_merging.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_performance.pb.swift /* unittest_swift_performance.pb.swift */,
+				F482B6771E856D1700A25EF8 /* unittest_swift_reserved_ext.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_reserved.pb.swift /* unittest_swift_reserved.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_runtime_proto2.pb.swift /* unittest_swift_runtime_proto2.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_runtime_proto3.pb.swift /* unittest_swift_runtime_proto3.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_swift_startup.pb.swift /* unittest_swift_startup.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest_well_known_types.pb.swift /* unittest_well_known_types.pb.swift */,
+				__PBXFileRef_Tests/ProtobufTests/unittest.pb.swift /* unittest.pb.swift */,
+			);
+			name = SwiftProtobufTests;
+			path = Tests/SwiftProtobufTests;
+			sourceTree = "<group>";
+		};
+		"_______Tests_" /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				"_______Group_ProtobufTestSuite" /* SwiftProtobufTests */,
+			);
+			name = Tests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9C8CDA111D7A288E00E207CA /* SwiftProtobufTestSuite_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9C8CDA1A1D7A288E00E207CA /* Build configuration list for PBXNativeTarget "SwiftProtobufTestSuite_iOS" */;
+			buildPhases = (
+				9C8CDA0E1D7A288E00E207CA /* Sources */,
+				9C8CDA0F1D7A288E00E207CA /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9C8CDA191D7A288E00E207CA /* PBXTargetDependency */,
+			);
+			name = SwiftProtobufTestSuite_iOS;
+			productName = ProtobufTestSuite_iOS;
+			productReference = "_____Product_ProtobufTestSuite_iOS" /* SwiftProtobufTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		BD12FD351D767BA0001815C7 /* SwiftProtobuf_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BD12FD3D1D767BA1001815C7 /* Build configuration list for PBXNativeTarget "SwiftProtobuf_iOS" */;
+			buildPhases = (
+				BD12FD311D767BA0001815C7 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftProtobuf_iOS;
+			productName = Protobuf_iOS;
+			productReference = "_____Product_Protobuf_iOS" /* SwiftProtobuf.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		F44F936E1DAEA53900BC5B85 /* SwiftProtobuf_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F44F93761DAEA53900BC5B85 /* Build configuration list for PBXNativeTarget "SwiftProtobuf_tvOS" */;
+			buildPhases = (
+				F44F936A1DAEA53900BC5B85 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftProtobuf_tvOS;
+			productName = SwiftProtobuf_tvOS;
+			productReference = F44F936F1DAEA53900BC5B85 /* SwiftProtobuf.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		F44F939E1DAEA7C500BC5B85 /* SwiftProtobufTestSuite_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F44F93A71DAEA7C500BC5B85 /* Build configuration list for PBXNativeTarget "SwiftProtobufTestSuite_tvOS" */;
+			buildPhases = (
+				F44F939B1DAEA7C500BC5B85 /* Sources */,
+				F44F939C1DAEA7C500BC5B85 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F44F93A61DAEA7C500BC5B85 /* PBXTargetDependency */,
+			);
+			name = SwiftProtobufTestSuite_tvOS;
+			productName = SwiftProtobufTestSuite_tvOS;
+			productReference = F44F939F1DAEA7C500BC5B85 /* SwiftProtobufTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		F44F93FD1DAEB13F00BC5B85 /* SwiftProtobuf_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F44F94051DAEB13F00BC5B85 /* Build configuration list for PBXNativeTarget "SwiftProtobuf_watchOS" */;
+			buildPhases = (
+				F44F93F91DAEB13F00BC5B85 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftProtobuf_watchOS;
+			productName = SwiftProtobuf_watchOS;
+			productReference = F44F93FE1DAEB13F00BC5B85 /* SwiftProtobuf.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"______Target_Protobuf" /* SwiftProtobuf_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = "_______Confs_Protobuf" /* Build configuration list for PBXNativeTarget "SwiftProtobuf_macOS" */;
+			buildPhases = (
+				CompilePhase_Protobuf /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftProtobuf_macOS;
+			productName = Protobuf;
+			productReference = "_____Product_Protobuf_macOS" /* SwiftProtobuf.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"______Target_ProtobufTestSuite" /* SwiftProtobufTestSuite_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = "_______Confs_ProtobufTestSuite" /* Build configuration list for PBXNativeTarget "SwiftProtobufTestSuite_macOS" */;
+			buildPhases = (
+				CompilePhase_ProtobufTestSuite /* Sources */,
+				"___LinkPhase_ProtobufTestSuite" /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				__Dependency_Protobuf /* PBXTargetDependency */,
+			);
+			name = SwiftProtobufTestSuite_macOS;
+			productName = ProtobufTestSuite;
+			productReference = "_____Product_ProtobufTestSuite_macOS" /* SwiftProtobufTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		__RootObject_ /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0800;
+				LastUpgradeCheck = 1010;
+				TargetAttributes = {
+					9C8CDA111D7A288E00E207CA = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
+					BD12FD351D767BA0001815C7 = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Manual;
+					};
+					F44F936E1DAEA53900BC5B85 = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Manual;
+					};
+					F44F939E1DAEA7C500BC5B85 = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
+					F44F93FD1DAEB13F00BC5B85 = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Manual;
+					};
+					"______Target_Protobuf" = {
+						LastSwiftMigration = 1010;
+					};
+					"______Target_ProtobufTestSuite" = {
+						LastSwiftMigration = 1010;
+					};
+				};
+			};
+			buildConfigurationList = "___RootConfs_" /* Build configuration list for PBXProject "SwiftProtobuf" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				English,
+				en,
+			);
+			mainGroup = "___RootGroup_";
+			productRefGroup = "____Products_" /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"______Target_Protobuf" /* SwiftProtobuf_macOS */,
+				"______Target_ProtobufTestSuite" /* SwiftProtobufTestSuite_macOS */,
+				BD12FD351D767BA0001815C7 /* SwiftProtobuf_iOS */,
+				9C8CDA111D7A288E00E207CA /* SwiftProtobufTestSuite_iOS */,
+				F44F936E1DAEA53900BC5B85 /* SwiftProtobuf_tvOS */,
+				F44F939E1DAEA7C500BC5B85 /* SwiftProtobufTestSuite_tvOS */,
+				F44F93FD1DAEB13F00BC5B85 /* SwiftProtobuf_watchOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9C8CDA0E1D7A288E00E207CA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4151F671EF3197200EEA00B /* Test_SimpleExtensionMap.swift in Sources */,
+				F47CF9A223E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift in Sources */,
+				9C8CDA1D1D7A28F600E207CA /* any_test.pb.swift in Sources */,
+				F40D33EB2017ED2200ABAF0F /* unittest_swift_enum_proto3.pb.swift in Sources */,
+				9C8CDA1E1D7A28F600E207CA /* conformance.pb.swift in Sources */,
+				9C8CDA211D7A28F600E207CA /* map_unittest.pb.swift in Sources */,
+				AAEA52211DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift in Sources */,
+				AAE0F4E01E6A3886005240E0 /* Test_EnumWithAliases.swift in Sources */,
+				F4C3A9721E96A08F006BB610 /* unittest_swift_oneof_all_required.pb.swift in Sources */,
+				9C8CDA201D7A28F600E207CA /* TestHelpers.swift in Sources */,
+				9C8CDA231D7A28F600E207CA /* Test_AllTypes.swift in Sources */,
+				9CCD5F941E008203002D1940 /* Test_TextFormat_WKT_proto3.swift in Sources */,
+				F482B6941E857BC100A25EF8 /* unittest_swift_naming_no_prefix.pb.swift in Sources */,
+				9C8CDA241D7A28F600E207CA /* Test_AllTypes_Proto3.swift in Sources */,
+				9C8CDA251D7A28F600E207CA /* Test_Any.swift in Sources */,
+				9C8CDA261D7A28F600E207CA /* Test_Api.swift in Sources */,
+				F44F94361DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */,
+				9CC8CAB31EC512A0008EF45F /* generated_swift_names_fields.pb.swift in Sources */,
+				F44F943B1DBFBB7500BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */,
+				F4151F781EFAD85B00EEA00B /* Test_BinaryDelimited.swift in Sources */,
+				9C8CDA271D7A28F600E207CA /* Test_Conformance.swift in Sources */,
+				9C8CDA291D7A28F600E207CA /* Test_Duration.swift in Sources */,
+				9C8CDA2A1D7A28F600E207CA /* Test_Empty.swift in Sources */,
+				AA6CF6F61DB6D228007DF26B /* Test_Enum_Proto2.swift in Sources */,
+				9C8CDA2B1D7A28F600E207CA /* Test_Enum.swift in Sources */,
+				9C8CDA2C1D7A28F600E207CA /* Test_Extensions.swift in Sources */,
+				9C8CDA2D1D7A28F600E207CA /* Test_ExtremeDefaultValues.swift in Sources */,
+				9C8CDA2E1D7A28F600E207CA /* Test_FieldMask.swift in Sources */,
+				9C8CDA2F1D7A28F600E207CA /* Test_FieldOrdering.swift in Sources */,
+				9C8CDA301D7A28F600E207CA /* Test_JSON.swift in Sources */,
+				9C8CDA311D7A28F600E207CA /* Test_JSON_Conformance.swift in Sources */,
+				9CC8CAB01EC512A0008EF45F /* generated_swift_names_enums.pb.swift in Sources */,
+				F4A1A8AE1E65E2F00022E078 /* map_proto2_unittest.pb.swift in Sources */,
+				9C8CDA321D7A28F600E207CA /* Test_JSON_Group.swift in Sources */,
+				9C8CDA341D7A28F600E207CA /* Test_Map.swift in Sources */,
+				F44F94491DBFF18000BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */,
+				F44F944E1DBFF8DC00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */,
+				9C8CDA351D7A28F600E207CA /* Test_Map_JSON.swift in Sources */,
+				F4F4F1191E5633E8006C6CAD /* Test_Naming.swift in Sources */,
+				F4584DB51EDDCA8800803AB6 /* Test_JSONDecodingOptions.swift in Sources */,
+				9CC8CAB61EC512A0008EF45F /* generated_swift_names_messages.pb.swift in Sources */,
+				F44F943F1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */,
+				F44F94441DBFE0BF00BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */,
+				9C8CDA361D7A28F600E207CA /* Test_Packed.swift in Sources */,
+				F451075923A2B9B500488257 /* Data+TestHelpers.swift in Sources */,
+				F4539D271E688B040076251F /* Test_GroupWithGroups.swift in Sources */,
+				9C8CDA371D7A28F600E207CA /* Test_ParsingMerge.swift in Sources */,
+				9C60CBED1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift in Sources */,
+				9C8CDA391D7A28F600E207CA /* Test_ReallyLargeTagNumber.swift in Sources */,
+				9C8CDA3A1D7A28F600E207CA /* Test_RecursiveMap.swift in Sources */,
+				9C60CBE91DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift in Sources */,
+				9C8CDA3B1D7A28F600E207CA /* Test_Required.swift in Sources */,
+				9C8CDA3C1D7A28F600E207CA /* Test_Reserved.swift in Sources */,
+				9C8CDA3D1D7A28F600E207CA /* Test_Struct.swift in Sources */,
+				9C8CDA3E1D7A28F600E207CA /* Test_Timestamp.swift in Sources */,
+				9C8CDA3F1D7A28F600E207CA /* Test_Type.swift in Sources */,
+				DB2E0AFB1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */,
+				F48FDD281E4D18060061D5C1 /* Test_TextFormat_proto3.swift in Sources */,
+				9C8CDA401D7A28F600E207CA /* Test_Unknown_proto2.swift in Sources */,
+				9C8CDA411D7A28F600E207CA /* Test_Unknown_proto3.swift in Sources */,
+				9C8CDA421D7A28F600E207CA /* Test_Wrappers.swift in Sources */,
+				9C8CDA431D7A28F600E207CA /* unittest.pb.swift in Sources */,
+				9C8CDA441D7A28F600E207CA /* unittest_arena.pb.swift in Sources */,
+				F48FDD271E4D18060061D5C1 /* Test_TextFormat_proto2_extensions.swift in Sources */,
+				9C8CDA451D7A28F600E207CA /* unittest_custom_options.pb.swift in Sources */,
+				9C8CDA461D7A28F600E207CA /* unittest_drop_unknown_fields.pb.swift in Sources */,
+				9C8CDA471D7A28F600E207CA /* unittest_embed_optimize_for.pb.swift in Sources */,
+				9C8CDA481D7A28F600E207CA /* unittest_empty.pb.swift in Sources */,
+				F411FEAD1EDDDC61001AE6B2 /* Test_BinaryDecodingOptions.swift in Sources */,
+				9C8CDA491D7A28F600E207CA /* unittest_import.pb.swift in Sources */,
+				9C8CDA4A1D7A28F600E207CA /* unittest_import_lite.pb.swift in Sources */,
+				AA3640971E60EBB0000C3CF4 /* Test_Merge.swift in Sources */,
+				F45D73FE1EE9984B00E0A231 /* Test_MessageSet.swift in Sources */,
+				9C8CDA4C1D7A28F600E207CA /* unittest_import_public.pb.swift in Sources */,
+				9C8CDA4D1D7A28F600E207CA /* unittest_import_public_lite.pb.swift in Sources */,
+				9C8CDA4F1D7A28F600E207CA /* unittest_lite.pb.swift in Sources */,
+				9C8CDA501D7A28F600E207CA /* unittest_lite_imports_nonlite.pb.swift in Sources */,
+				9C8CDA511D7A28F600E207CA /* unittest_mset.pb.swift in Sources */,
+				F4D3154A1DEC811B005D4A80 /* unittest_swift_extension3.pb.swift in Sources */,
+				F4584D3C1ECA4FC700803AB6 /* unittest_swift_oneof_merging.pb.swift in Sources */,
+				9C8CDA641D7A28F600E207CA /* unittest_swift_naming.pb.swift in Sources */,
+				F4A07B2D1E4A3E630035678A /* test_messages_proto3.pb.swift in Sources */,
+				9C8CDA521D7A28F600E207CA /* unittest_mset_wire_format.pb.swift in Sources */,
+				9C8CDA531D7A28F600E207CA /* unittest_no_arena.pb.swift in Sources */,
+				F47C42B62437A3C700C08579 /* unittest_proto3_optional.pb.swift in Sources */,
+				9C8CDA541D7A28F600E207CA /* unittest_no_arena_import.pb.swift in Sources */,
+				9C8CDA551D7A28F600E207CA /* unittest_no_arena_lite.pb.swift in Sources */,
+				9C8CDA561D7A28F600E207CA /* unittest_no_field_presence.pb.swift in Sources */,
+				F47C42C32437A73000C08579 /* Test_AllTypes_Proto3_Optional.swift in Sources */,
+				9C8CDA571D7A28F600E207CA /* unittest_no_generic_services.pb.swift in Sources */,
+				9C8CDA581D7A28F600E207CA /* unittest_optimize_for.pb.swift in Sources */,
+				9C8CDA591D7A28F600E207CA /* unittest_preserve_unknown_enum.pb.swift in Sources */,
+				9C8CDA5A1D7A28F600E207CA /* unittest_preserve_unknown_enum2.pb.swift in Sources */,
+				9C8CDA5C1D7A28F600E207CA /* unittest_proto3_arena.pb.swift in Sources */,
+				9C8CDA5B1D7A28F600E207CA /* unittest_proto3.pb.swift in Sources */,
+				9C8CDA5D1D7A28F600E207CA /* unittest_swift_all_required_types.pb.swift in Sources */,
+				9C8CDA5E1D7A28F600E207CA /* unittest_swift_cycle.pb.swift in Sources */,
+				9C7254671E5F9B1600486C98 /* Test_TextFormat_Unknown.swift in Sources */,
+				9C8CDA611D7A28F600E207CA /* unittest_swift_extension.pb.swift in Sources */,
+				F4D315491DEC811B005D4A80 /* unittest_swift_extension2.pb.swift in Sources */,
+				F4D315551DECA0EA005D4A80 /* unittest_swift_extension4.pb.swift in Sources */,
+				9C8CDA5F1D7A28F600E207CA /* unittest_swift_enum.pb.swift in Sources */,
+				9C8CDA601D7A28F600E207CA /* unittest_swift_enum_optional_default.pb.swift in Sources */,
+				9C8CDA621D7A28F600E207CA /* unittest_swift_fieldorder.pb.swift in Sources */,
+				9C8CDA631D7A28F600E207CA /* unittest_swift_groups.pb.swift in Sources */,
+				9C8CDA651D7A28F600E207CA /* unittest_swift_performance.pb.swift in Sources */,
+				F4618B652154245600E5FABA /* Test_JSONEncodingOptions.swift in Sources */,
+				9C8CDA661D7A28F600E207CA /* unittest_swift_reserved.pb.swift in Sources */,
+				F482B67A1E856D2700A25EF8 /* unittest_swift_reserved_ext.pb.swift in Sources */,
+				9C8CDA671D7A28F600E207CA /* unittest_swift_runtime_proto2.pb.swift in Sources */,
+				9C8CDA681D7A28F600E207CA /* unittest_swift_runtime_proto3.pb.swift in Sources */,
+				9CC8CAAD1EC512A0008EF45F /* generated_swift_names_enum_cases.pb.swift in Sources */,
+				9C8CDA691D7A28F600E207CA /* unittest_swift_startup.pb.swift in Sources */,
+				9C8CDA6A1D7A28F600E207CA /* unittest_well_known_types.pb.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BD12FD311D767BA0001815C7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0353A1CE1E81623B00067996 /* any.pb.swift in Sources */,
+				9C2F237B1D7780D1008524F2 /* api.pb.swift in Sources */,
+				9C2F237C1D7780D1008524F2 /* duration.pb.swift in Sources */,
+				F4618B572154151700E5FABA /* JSONEncodingOptions.swift in Sources */,
+				9C2F237D1D7780D1008524F2 /* empty.pb.swift in Sources */,
+				9C75F89F1DDD3FA3005CCFF2 /* JSONDecoder.swift in Sources */,
+				9C2F237E1D7780D1008524F2 /* field_mask.pb.swift in Sources */,
+				AAE0F4E41E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift in Sources */,
+				9C2F23801D7780D1008524F2 /* Google_Protobuf_Duration+Extensions.swift in Sources */,
+				9C2F23811D7780D1008524F2 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */,
+				F47138971E4E56AC00C8492C /* Internal.swift in Sources */,
+				AA28A4AD1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift in Sources */,
+				9C2F23821D7780D1008524F2 /* Google_Protobuf_Struct+Extensions.swift in Sources */,
+				9CA424431E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
+				DB2E0AFF1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */,
+				AA78AD371E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */,
+				9C2F23831D7780D1008524F2 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */,
+				F411FE9C1EDDD706001AE6B2 /* JSONDecodingOptions.swift in Sources */,
+				9C2F23851D7780D1008524F2 /* BinaryDecoder.swift in Sources */,
+				AA3640921E60D592000C3CF4 /* struct.pb.swift in Sources */,
+				9C2F23861D7780D1008524F2 /* BinaryEncoder.swift in Sources */,
+				F4EDCC2C22DF896500A1ECB7 /* DoubleParser.swift in Sources */,
+				F4E852B71EE9D84800AE837E /* SelectiveVisitor.swift in Sources */,
+				F41BA4431E7B35C6004F6E95 /* AnyMessageStorage.swift in Sources */,
+				9C2F23871D7780D1008524F2 /* Message+BinaryAdditions.swift in Sources */,
+				9C2F23891D7780D1008524F2 /* Enum.swift in Sources */,
+				9C2F238B1D7780D1008524F2 /* ExtensionFields.swift in Sources */,
+				F41BA3FD1E76F639004F6E95 /* Google_Protobuf_Any+Registry.swift in Sources */,
+				9C75F88B1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */,
+				F48769F923020B7D00D44224 /* descriptor.pb.swift in Sources */,
+				F4F4F11E1E5C7562006C6CAD /* MathUtils.swift in Sources */,
+				9C84E4941E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */,
+				AA86F6FB1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */,
+				F41BA4141E79BE54004F6E95 /* Google_Protobuf_Any+Extensions.swift in Sources */,
+				E7038A25224D7F1000B68775 /* Data+Extensions.swift in Sources */,
+				9C2F238C1D7780D1008524F2 /* MessageExtension.swift in Sources */,
+				9C667A961E4C203D008B974F /* BinaryDecodingError.swift in Sources */,
+				9C2F238D1D7780D1008524F2 /* Decoder.swift in Sources */,
+				9C2F238F1D7780D1008524F2 /* HashVisitor.swift in Sources */,
+				AAABA40C1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */,
+				AAF2ED401DEF4D94007B510F /* ProtoNameProviding.swift in Sources */,
+				F4151F721EFAB83900EEA00B /* BinaryDelimited.swift in Sources */,
+				AAF2ED3B1DEF3FBC007B510F /* NameMap.swift in Sources */,
+				F411FEA01EDDD83C001AE6B2 /* BinaryDecodingOptions.swift in Sources */,
+				AA05BF501DAEB7E800619042 /* FieldTag.swift in Sources */,
+				9C75F8A41DDD44A1005CCFF2 /* ProtobufMap.swift in Sources */,
+				AA28A4AA1DA40B0900C866D9 /* Varint.swift in Sources */,
+				F41BA4191E79C59A004F6E95 /* AnyUnpackError.swift in Sources */,
+				9C2F23911D7780D1008524F2 /* JSONEncoder.swift in Sources */,
+				9C2F23921D7780D1008524F2 /* Message+JSONAdditions.swift in Sources */,
+				F4539D2B1E6F5DD40076251F /* CustomJSONCodable.swift in Sources */,
+				AAEA52771DA832A8003F318F /* wrappers.pb.swift in Sources */,
+				9C2F23931D7780D1008524F2 /* Message.swift in Sources */,
+				F4F4F11B1E5C7556006C6CAD /* TimeUtils.swift in Sources */,
+				F482B6B61E89941500A25EF8 /* Version.swift in Sources */,
+				9C2F23981D7780D1008524F2 /* FieldTypes.swift in Sources */,
+				9C2F23991D7780D1008524F2 /* UnknownStorage.swift in Sources */,
+				9C5890B41DFF6389001CFC34 /* TextFormatDecoder.swift in Sources */,
+				9C5890B51DFF6389001CFC34 /* TextFormatEncoder.swift in Sources */,
+				9C5890B61DFF6389001CFC34 /* TextFormatEncodingVisitor.swift in Sources */,
+				9C5890B71DFF6389001CFC34 /* TextFormatScanner.swift in Sources */,
+				9C5890B91DFF6389001CFC34 /* Message+TextFormatAdditions.swift in Sources */,
+				F451074B23A288E400488257 /* UnsafeBufferPointer+Shims.swift in Sources */,
+				9C4178621E809DA2007830C3 /* ExtensionMap.swift in Sources */,
+				F48FDD241E4D17ED0061D5C1 /* JSONScanner.swift in Sources */,
+				9C75F8861DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */,
+				F451074723A288E400488257 /* UnsafeRawPointer+Shims.swift in Sources */,
+				9C84E4901E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
+				9C75F8811DDBE0FC005CCFF2 /* Visitor.swift in Sources */,
+				9C0B366C1E5FAB910094E128 /* JSONMapEncodingVisitor.swift in Sources */,
+				9C2F239B1D7780D1008524F2 /* source_context.pb.swift in Sources */,
+				9C2F239C1D7780D1008524F2 /* timestamp.pb.swift in Sources */,
+				AA28A4A71DA30E5900C866D9 /* ZigZag.swift in Sources */,
+				9C2F239D1D7780D1008524F2 /* type.pb.swift in Sources */,
+				9C75F8951DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift in Sources */,
+				F49B576C2252771700350FFD /* TextFormatEncodingOptions.swift in Sources */,
+				AAB979F61E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift in Sources */,
+				AA05BF4B1DAEB7E400619042 /* WireFormat.swift in Sources */,
+				9C667A921E4C203D008B974F /* JSONDecodingError.swift in Sources */,
+				F44F93691DAD7FA500BC5B85 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
+				9C667A9A1E4C203D008B974F /* TextFormatDecodingError.swift in Sources */,
+				9C75F8901DDD3108005CCFF2 /* ExtensibleMessage.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CompilePhase_Protobuf /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				F41BA4421E7AE53C004F6E95 /* AnyMessageStorage.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/api.pb.swift /* api.pb.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/duration.pb.swift /* duration.pb.swift in Sources */,
+				F4618B562154151700E5FABA /* JSONEncodingOptions.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/empty.pb.swift /* empty.pb.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift in Sources */,
+				9C75F88F1DDD3108005CCFF2 /* ExtensibleMessage.swift in Sources */,
+				AAE0F4E31E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift in Sources */,
+				8DC1CA0F1E54B81400CA8A26 /* TimeUtils.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift in Sources */,
+				9C4178611E809DA2007830C3 /* ExtensionMap.swift in Sources */,
+				9C75F88A1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */,
+				F47138961E4E56AC00C8492C /* Internal.swift in Sources */,
+				9C75F8851DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift in Sources */,
+				DB2E0AFE1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */,
+				AA78AD361E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */,
+				AAF2ED3A1DEF3FBC007B510F /* NameMap.swift in Sources */,
+				F4584DB81EDDCAD600803AB6 /* JSONDecodingOptions.swift in Sources */,
+				9CA424421E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
+				AA05BF4F1DAEB7E800619042 /* FieldTag.swift in Sources */,
+				F4EDCC2B22DF896500A1ECB7 /* DoubleParser.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufTypes.swift /* FieldTypes.swift in Sources */,
+				F4E852B61EE9D83C00AE837E /* SelectiveVisitor.swift in Sources */,
+				AA3640911E60D043000C3CF4 /* struct.pb.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/field_mask.pb.swift /* field_mask.pb.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration+Extensions.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/Google_Protobuf_FieldMask_Extensions.swift /* Google_Protobuf_FieldMask+Extensions.swift in Sources */,
+				F41BA3FC1E76F635004F6E95 /* Google_Protobuf_Any+Registry.swift in Sources */,
+				F48769F823020B7D00D44224 /* descriptor.pb.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct+Extensions.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/Google_Protobuf_Timestamp_Extensions.swift /* Google_Protobuf_Timestamp+Extensions.swift in Sources */,
+				9C84E4931E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */,
+				8DC1CA0D1E54B80800CA8A26 /* MathUtils.swift in Sources */,
+				E7038A24224D7F1000B68775 /* Data+Extensions.swift in Sources */,
+				F41BA4131E79BDCA004F6E95 /* Google_Protobuf_Any+Extensions.swift in Sources */,
+				AAEA52721DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
+				AAABA40B1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */,
+				9C667A951E4C203D008B974F /* BinaryDecodingError.swift in Sources */,
+				AA86F6FA1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufHash.swift /* HashVisitor.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufJSONEncoding.swift /* JSONEncoder.swift in Sources */,
+				F4151F711EFAB83400EEA00B /* BinaryDelimited.swift in Sources */,
+				F411FE9F1EDDD83B001AE6B2 /* BinaryDecodingOptions.swift in Sources */,
+				9C75F89E1DDD3FA3005CCFF2 /* JSONDecoder.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufJSONTypes.swift /* Message+JSONAdditions.swift in Sources */,
+				9C75F8A31DDD44A1005CCFF2 /* ProtobufMap.swift in Sources */,
+				F41BA4181E79C568004F6E95 /* AnyUnpackError.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufMessage.swift /* Message.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift in Sources */,
+				F4539D2A1E6F5DC70076251F /* CustomJSONCodable.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufBinaryDecoding.swift /* BinaryDecoder.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift in Sources */,
+				AA28A4AC1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift in Sources */,
+				F482B6B31E89940E00A25EF8 /* Version.swift in Sources */,
+				F41BA4401E7AE4AC004F6E95 /* any.pb.swift in Sources */,
+				9C75F8941DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufBinaryTypes.swift /* Message+BinaryAdditions.swift in Sources */,
+				AAF2ED3F1DEF4D94007B510F /* ProtoNameProviding.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift in Sources */,
+				BCCA0E691DB1210E00957D74 /* TextFormatDecoder.swift in Sources */,
+				BCCA0E6A1DB1210E00957D74 /* TextFormatEncoder.swift in Sources */,
+				F451074A23A288E400488257 /* UnsafeBufferPointer+Shims.swift in Sources */,
+				9C667A991E4C203D008B974F /* TextFormatDecodingError.swift in Sources */,
+				9CE9CF371E32C9F8004FBED6 /* JSONScanner.swift in Sources */,
+				9C84E48F1E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
+				F451074623A288E400488257 /* UnsafeRawPointer+Shims.swift in Sources */,
+				9C667A911E4C203D008B974F /* JSONDecodingError.swift in Sources */,
+				9C0B366B1E5FAB910094E128 /* JSONMapEncodingVisitor.swift in Sources */,
+				9CEB0D681DF5E934002D80F0 /* TextFormatEncodingVisitor.swift in Sources */,
+				9CEB0D6C1DF5F921002D80F0 /* TextFormatScanner.swift in Sources */,
+				BCCA0E6B1DB1210E00957D74 /* Message+TextFormatAdditions.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/type.pb.swift /* type.pb.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufUnknown.swift /* UnknownStorage.swift in Sources */,
+				F49B576B2252771700350FFD /* TextFormatEncodingOptions.swift in Sources */,
+				AAB979F51E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift in Sources */,
+				AA28A4A91DA40B0900C866D9 /* Varint.swift in Sources */,
+				9C75F8801DDBE0DE005CCFF2 /* Visitor.swift in Sources */,
+				AA05BF4A1DAEB7E400619042 /* WireFormat.swift in Sources */,
+				AAEA52741DA80DEA003F318F /* wrappers.pb.swift in Sources */,
+				AA28A4A61DA30E5900C866D9 /* ZigZag.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CompilePhase_ProtobufTestSuite /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				F4151F661EF3197100EEA00B /* Test_SimpleExtensionMap.swift in Sources */,
+				F47CF9A123E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift in Sources */,
+				F40D33EA2017ED2100ABAF0F /* unittest_swift_enum_proto3.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift in Sources */,
+				AAEA52201DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift in Sources */,
+				AAE0F4DF1E6A3886005240E0 /* Test_EnumWithAliases.swift in Sources */,
+				F4C3A9711E96A08E006BB610 /* unittest_swift_oneof_all_required.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift in Sources */,
+				F482B6931E857BC100A25EF8 /* unittest_swift_naming_no_prefix.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Api.swift /* Test_Api.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Conformance.swift /* Test_Conformance.swift in Sources */,
+				9CC8CAB21EC512A0008EF45F /* generated_swift_names_fields.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Duration.swift /* Test_Duration.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Empty.swift /* Test_Empty.swift in Sources */,
+				F4151F771EFAD85A00EEA00B /* Test_BinaryDelimited.swift in Sources */,
+				F44F94431DBFE0BE00BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Enum.swift /* Test_Enum.swift in Sources */,
+				AA6CF6F51DB6D227007DF26B /* Test_Enum_Proto2.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Extensions.swift /* Test_Extensions.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_ExtremeDefaultValues.swift /* Test_ExtremeDefaultValues.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_FieldMask.swift /* Test_FieldMask.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_FieldOrdering.swift /* Test_FieldOrdering.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_JSON.swift /* Test_JSON.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_JSON_Conformance.swift /* Test_JSON_Conformance.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_JSON_Group.swift /* Test_JSON_Group.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Map.swift /* Test_Map.swift in Sources */,
+				9CC8CAAF1EC512A0008EF45F /* generated_swift_names_enums.pb.swift in Sources */,
+				F4A1A8AD1E65E2EF0022E078 /* map_proto2_unittest.pb.swift in Sources */,
+				F44F94481DBFF17F00BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */,
+				F44F944D1DBFF8DB00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Map_JSON.swift /* Test_Map_JSON.swift in Sources */,
+				F44F943E1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Packed.swift /* Test_Packed.swift in Sources */,
+				F4F4F1181E5633E7006C6CAD /* Test_Naming.swift in Sources */,
+				F4584DB41EDDCA8700803AB6 /* Test_JSONDecodingOptions.swift in Sources */,
+				9CC8CAB51EC512A0008EF45F /* generated_swift_names_messages.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_ParsingMerge.swift /* Test_ParsingMerge.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_ReallyLargeTagNumber.swift /* Test_ReallyLargeTagNumber.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_RecursiveMap.swift /* Test_RecursiveMap.swift in Sources */,
+				F451075823A2B9B500488257 /* Data+TestHelpers.swift in Sources */,
+				F4539D261E688B030076251F /* Test_GroupWithGroups.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Required.swift /* Test_Required.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Reserved.swift /* Test_Reserved.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Struct.swift /* Test_Struct.swift in Sources */,
+				9C60CBEC1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift in Sources */,
+				9C5890A71DFF5FFC001CFC34 /* Test_TextFormat_proto2_extensions.swift in Sources */,
+				BCCA0E7A1DB124B800957D74 /* Test_TextFormat_proto3.swift in Sources */,
+				9CCD5F931E008203002D1940 /* Test_TextFormat_WKT_proto3.swift in Sources */,
+				F44F943A1DBFBB7400BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */,
+				F44F94351DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Timestamp.swift /* Test_Timestamp.swift in Sources */,
+				DB2E0AFA1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Type.swift /* Test_Type.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Unknown_proto2.swift /* Test_Unknown_proto2.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Unknown_proto3.swift /* Test_Unknown_proto3.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/Test_Wrappers.swift /* Test_Wrappers.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest.pb.swift /* unittest.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_arena.pb.swift /* unittest_arena.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_custom_options.pb.swift /* unittest_custom_options.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_drop_unknown_fields.pb.swift /* unittest_drop_unknown_fields.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_embed_optimize_for.pb.swift /* unittest_embed_optimize_for.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_empty.pb.swift /* unittest_empty.pb.swift in Sources */,
+				F4A07B2C1E4A3E620035678A /* test_messages_proto3.pb.swift in Sources */,
+				F411FEAC1EDDDC61001AE6B2 /* Test_BinaryDecodingOptions.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_import.pb.swift /* unittest_import.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_import_lite.pb.swift /* unittest_import_lite.pb.swift in Sources */,
+				AA3640961E60EBB0000C3CF4 /* Test_Merge.swift in Sources */,
+				F45D73FD1EE9984A00E0A231 /* Test_MessageSet.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_import_public.pb.swift /* unittest_import_public.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_import_public_lite.pb.swift /* unittest_import_public_lite.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_lite.pb.swift /* unittest_lite.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_lite_imports_nonlite.pb.swift /* unittest_lite_imports_nonlite.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_mset.pb.swift /* unittest_mset.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_mset_wire_format.pb.swift /* unittest_mset_wire_format.pb.swift in Sources */,
+				F4584D3B1ECA4FC600803AB6 /* unittest_swift_oneof_merging.pb.swift in Sources */,
+				9C60CBE81DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_no_arena.pb.swift /* unittest_no_arena.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_no_arena_import.pb.swift /* unittest_no_arena_import.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_no_arena_lite.pb.swift /* unittest_no_arena_lite.pb.swift in Sources */,
+				F47C42B52437A3C700C08579 /* unittest_proto3_optional.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_no_field_presence.pb.swift /* unittest_no_field_presence.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_no_generic_services.pb.swift /* unittest_no_generic_services.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_optimize_for.pb.swift /* unittest_optimize_for.pb.swift in Sources */,
+				F47C42C22437A73000C08579 /* Test_AllTypes_Proto3_Optional.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_preserve_unknown_enum.pb.swift /* unittest_preserve_unknown_enum.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_preserve_unknown_enum2.pb.swift /* unittest_preserve_unknown_enum2.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_proto3.pb.swift /* unittest_proto3.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_proto3_arena.pb.swift /* unittest_proto3_arena.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_all_required_types.pb.swift /* unittest_swift_all_required_types.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_cycle.pb.swift /* unittest_swift_cycle.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_enum.pb.swift /* unittest_swift_enum.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_enum_optional_default.pb.swift /* unittest_swift_enum_optional_default.pb.swift in Sources */,
+				9C7254661E5F9B1600486C98 /* Test_TextFormat_Unknown.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_extension.pb.swift /* unittest_swift_extension.pb.swift in Sources */,
+				F4D315471DEC8117005D4A80 /* unittest_swift_extension2.pb.swift in Sources */,
+				F4D315481DEC8117005D4A80 /* unittest_swift_extension3.pb.swift in Sources */,
+				F4D315541DECA0EA005D4A80 /* unittest_swift_extension4.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_fieldorder.pb.swift /* unittest_swift_fieldorder.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_groups.pb.swift /* unittest_swift_groups.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_naming.pb.swift /* unittest_swift_naming.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_performance.pb.swift /* unittest_swift_performance.pb.swift in Sources */,
+				F4618B642154245600E5FABA /* Test_JSONEncodingOptions.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_reserved.pb.swift /* unittest_swift_reserved.pb.swift in Sources */,
+				F482B6791E856D2600A25EF8 /* unittest_swift_reserved_ext.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_runtime_proto2.pb.swift /* unittest_swift_runtime_proto2.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_runtime_proto3.pb.swift /* unittest_swift_runtime_proto3.pb.swift in Sources */,
+				9CC8CAAC1EC512A0008EF45F /* generated_swift_names_enum_cases.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_swift_startup.pb.swift /* unittest_swift_startup.pb.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/unittest_well_known_types.pb.swift /* unittest_well_known_types.pb.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F44F936A1DAEA53900BC5B85 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0353A1CF1E81624F00067996 /* any.pb.swift in Sources */,
+				F44F93821DAEA76700BC5B85 /* BinaryEncoder.swift in Sources */,
+				F44F93961DAEA76700BC5B85 /* timestamp.pb.swift in Sources */,
+				F4618B582154151700E5FABA /* JSONEncodingOptions.swift in Sources */,
+				F44F93951DAEA76700BC5B85 /* source_context.pb.swift in Sources */,
+				9C75F8A01DDD3FA3005CCFF2 /* JSONDecoder.swift in Sources */,
+				F44F939A1DAEA76700BC5B85 /* ZigZag.swift in Sources */,
+				AAE0F4E51E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift in Sources */,
+				F44F93971DAEA76700BC5B85 /* type.pb.swift in Sources */,
+				F44F937F1DAEA76700BC5B85 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */,
+				F44F938E1DAEA76700BC5B85 /* Message+JSONAdditions.swift in Sources */,
+				F47138981E4E56AC00C8492C /* Internal.swift in Sources */,
+				F44F93801DAEA76700BC5B85 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
+				9CA424441E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
+				DB2E0B001EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */,
+				AA78AD381E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */,
+				F44F938F1DAEA76700BC5B85 /* Message.swift in Sources */,
+				F411FE9D1EDDD706001AE6B2 /* JSONDecodingOptions.swift in Sources */,
+				F44F93861DAEA76700BC5B85 /* Enum.swift in Sources */,
+				F44F938A1DAEA76700BC5B85 /* Decoder.swift in Sources */,
+				AA3640931E60D593000C3CF4 /* struct.pb.swift in Sources */,
+				F4EDCC2D22DF896500A1ECB7 /* DoubleParser.swift in Sources */,
+				F4E852B81EE9D84900AE837E /* SelectiveVisitor.swift in Sources */,
+				F41BA4441E7B35C7004F6E95 /* AnyMessageStorage.swift in Sources */,
+				F44F938D1DAEA76700BC5B85 /* JSONEncoder.swift in Sources */,
+				F44F938B1DAEA76700BC5B85 /* HashVisitor.swift in Sources */,
+				9C75F88C1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */,
+				AA86F6FC1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */,
+				F41BA3FE1E76F639004F6E95 /* Google_Protobuf_Any+Registry.swift in Sources */,
+				F48769FA23020B7D00D44224 /* descriptor.pb.swift in Sources */,
+				AAF2ED411DEF4D94007B510F /* ProtoNameProviding.swift in Sources */,
+				AAF2ED3C1DEF3FBC007B510F /* NameMap.swift in Sources */,
+				9C84E4951E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */,
+				F4F4F11F1E5C7563006C6CAD /* MathUtils.swift in Sources */,
+				E7038A26224D7F1000B68775 /* Data+Extensions.swift in Sources */,
+				F41BA4151E79BE55004F6E95 /* Google_Protobuf_Any+Extensions.swift in Sources */,
+				F44F937E1DAEA76700BC5B85 /* Google_Protobuf_Struct+Extensions.swift in Sources */,
+				9C667A971E4C203D008B974F /* BinaryDecodingError.swift in Sources */,
+				F44F93941DAEA76700BC5B85 /* UnknownStorage.swift in Sources */,
+				9C75F8821DDBE10D005CCFF2 /* Visitor.swift in Sources */,
+				AAABA40D1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */,
+				F4151F731EFAB83A00EEA00B /* BinaryDelimited.swift in Sources */,
+				F44F93781DAEA76700BC5B85 /* duration.pb.swift in Sources */,
+				F411FEA11EDDD83D001AE6B2 /* BinaryDecodingOptions.swift in Sources */,
+				AA05BF511DAEB7E800619042 /* FieldTag.swift in Sources */,
+				9C75F8A51DDD44A1005CCFF2 /* ProtobufMap.swift in Sources */,
+				F44F937A1DAEA76700BC5B85 /* field_mask.pb.swift in Sources */,
+				F44F93831DAEA76700BC5B85 /* BinaryEncodingSizeVisitor.swift in Sources */,
+				F41BA41A1E79C59B004F6E95 /* AnyUnpackError.swift in Sources */,
+				F44F93841DAEA76700BC5B85 /* Message+BinaryAdditions.swift in Sources */,
+				F4539D2C1E6F5DD50076251F /* CustomJSONCodable.swift in Sources */,
+				F44F93991DAEA76700BC5B85 /* wrappers.pb.swift in Sources */,
+				F44F93811DAEA76700BC5B85 /* BinaryDecoder.swift in Sources */,
+				F4F4F11C1E5C7556006C6CAD /* TimeUtils.swift in Sources */,
+				F482B6B71E89941600A25EF8 /* Version.swift in Sources */,
+				F44F93981DAEA76700BC5B85 /* Varint.swift in Sources */,
+				F44F937C1DAEA76700BC5B85 /* Google_Protobuf_Duration+Extensions.swift in Sources */,
+				9C5890AE1DFF6384001CFC34 /* TextFormatDecoder.swift in Sources */,
+				9C5890AF1DFF6384001CFC34 /* TextFormatEncoder.swift in Sources */,
+				9C5890B01DFF6384001CFC34 /* TextFormatEncodingVisitor.swift in Sources */,
+				9C5890B11DFF6384001CFC34 /* TextFormatScanner.swift in Sources */,
+				9C5890B31DFF6384001CFC34 /* Message+TextFormatAdditions.swift in Sources */,
+				F451074C23A288E400488257 /* UnsafeBufferPointer+Shims.swift in Sources */,
+				9C4178631E809DA2007830C3 /* ExtensionMap.swift in Sources */,
+				F48FDD251E4D17EE0061D5C1 /* JSONScanner.swift in Sources */,
+				9C84E4911E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
+				F451074823A288E400488257 /* UnsafeRawPointer+Shims.swift in Sources */,
+				F44F93931DAEA76700BC5B85 /* FieldTypes.swift in Sources */,
+				9C0B366D1E5FAB910094E128 /* JSONMapEncodingVisitor.swift in Sources */,
+				9C75F8871DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */,
+				F44F937D1DAEA76700BC5B85 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */,
+				F44F93771DAEA76700BC5B85 /* api.pb.swift in Sources */,
+				F44F93791DAEA76700BC5B85 /* empty.pb.swift in Sources */,
+				F44F93891DAEA76700BC5B85 /* MessageExtension.swift in Sources */,
+				9C75F8961DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift in Sources */,
+				F49B576D2252771700350FFD /* TextFormatEncodingOptions.swift in Sources */,
+				AAB979F71E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift in Sources */,
+				AA05BF4C1DAEB7E400619042 /* WireFormat.swift in Sources */,
+				9C667A931E4C203D008B974F /* JSONDecodingError.swift in Sources */,
+				F44F93881DAEA76700BC5B85 /* ExtensionFields.swift in Sources */,
+				9C667A9B1E4C203D008B974F /* TextFormatDecodingError.swift in Sources */,
+				9C75F8911DDD3108005CCFF2 /* ExtensibleMessage.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F44F939B1DAEA7C500BC5B85 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4151F681EF3197300EEA00B /* Test_SimpleExtensionMap.swift in Sources */,
+				F47CF9A323E88DD000C7B24C /* unittest_swift_naming_number_prefix.pb.swift in Sources */,
+				F44F93BD1DAEA8C900BC5B85 /* Test_FieldOrdering.swift in Sources */,
+				F40D33EC2017ED2300ABAF0F /* unittest_swift_enum_proto3.pb.swift in Sources */,
+				F44F93C21DAEA8C900BC5B85 /* Test_Map_JSON.swift in Sources */,
+				F44F93DD1DAEA8C900BC5B85 /* unittest_lite.pb.swift in Sources */,
+				F44F93B31DAEA8C900BC5B85 /* Test_Any.swift in Sources */,
+				F44F93B71DAEA8C900BC5B85 /* Test_Duration.swift in Sources */,
+				AAE0F4E11E6A3886005240E0 /* Test_EnumWithAliases.swift in Sources */,
+				F4C3A9731E96A090006BB610 /* unittest_swift_oneof_all_required.pb.swift in Sources */,
+				F44F93DF1DAEA8C900BC5B85 /* unittest_mset.pb.swift in Sources */,
+				F44F93D51DAEA8C900BC5B85 /* unittest_empty.pb.swift in Sources */,
+				F44F93C11DAEA8C900BC5B85 /* Test_JSON.swift in Sources */,
+				F482B6951E857BC200A25EF8 /* unittest_swift_naming_no_prefix.pb.swift in Sources */,
+				9CCD5F951E008203002D1940 /* Test_TextFormat_WKT_proto3.swift in Sources */,
+				F44F93E21DAEA8C900BC5B85 /* unittest_no_arena.pb.swift in Sources */,
+				F44F93EB1DAEA8C900BC5B85 /* unittest_swift_cycle.pb.swift in Sources */,
+				F44F93C81DAEA8C900BC5B85 /* Test_RecursiveMap.swift in Sources */,
+				9CC8CAB41EC512A0008EF45F /* generated_swift_names_fields.pb.swift in Sources */,
+				F44F93D81DAEA8C900BC5B85 /* unittest_import_public_lite.pb.swift in Sources */,
+				F4151F791EFAD85C00EEA00B /* Test_BinaryDelimited.swift in Sources */,
+				F44F93E01DAEA8C900BC5B85 /* unittest_no_arena_import.pb.swift in Sources */,
+				F44F93B81DAEA8C900BC5B85 /* Test_Empty.swift in Sources */,
+				F44F93B11DAEA8C900BC5B85 /* Test_AllTypes_Proto3.swift in Sources */,
+				F44F94451DBFE0C000BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */,
+				F44F93DC1DAEA8C900BC5B85 /* unittest_lite_imports_nonlite.pb.swift in Sources */,
+				F44F93F01DAEA8C900BC5B85 /* unittest_swift_groups.pb.swift in Sources */,
+				F44F93EE1DAEA8C900BC5B85 /* unittest_swift_extension.pb.swift in Sources */,
+				F44F93D31DAEA8C900BC5B85 /* unittest_drop_unknown_fields.pb.swift in Sources */,
+				F44F93BA1DAEA8C900BC5B85 /* Test_Extensions.swift in Sources */,
+				F44F93B51DAEA8C900BC5B85 /* Test_Conformance.swift in Sources */,
+				F44F93E71DAEA8C900BC5B85 /* unittest_preserve_unknown_enum2.pb.swift in Sources */,
+				F44F93CD1DAEA8C900BC5B85 /* Test_Type.swift in Sources */,
+				9CC8CAB11EC512A0008EF45F /* generated_swift_names_enums.pb.swift in Sources */,
+				F4A1A8AF1E65E2F10022E078 /* map_proto2_unittest.pb.swift in Sources */,
+				F44F93AB1DAEA8C900BC5B85 /* conformance.pb.swift in Sources */,
+				F44F93E31DAEA8C900BC5B85 /* unittest_no_field_presence.pb.swift in Sources */,
+				F44F93AA1DAEA8C900BC5B85 /* any_test.pb.swift in Sources */,
+				F44F93AF1DAEA8C900BC5B85 /* map_unittest.pb.swift in Sources */,
+				F44F93C91DAEA8C900BC5B85 /* Test_Required.swift in Sources */,
+				F4584DB61EDDCA8900803AB6 /* Test_JSONDecodingOptions.swift in Sources */,
+				F4F4F11A1E5633EA006C6CAD /* Test_Naming.swift in Sources */,
+				9CC8CAB71EC512A0008EF45F /* generated_swift_names_messages.pb.swift in Sources */,
+				F44F93D11DAEA8C900BC5B85 /* unittest_arena.pb.swift in Sources */,
+				F451075A23A2B9B500488257 /* Data+TestHelpers.swift in Sources */,
+				F44F93EC1DAEA8C900BC5B85 /* unittest_swift_enum_optional_default.pb.swift in Sources */,
+				F4539D281E688B050076251F /* Test_GroupWithGroups.swift in Sources */,
+				F44F93BB1DAEA8C900BC5B85 /* Test_ExtremeDefaultValues.swift in Sources */,
+				F44F93EF1DAEA8C900BC5B85 /* unittest_swift_fieldorder.pb.swift in Sources */,
+				9C60CBEE1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift in Sources */,
+				F44F93F81DAEA8C900BC5B85 /* unittest.pb.swift in Sources */,
+				F44F93E81DAEA8C900BC5B85 /* unittest_proto3_arena.pb.swift in Sources */,
+				9C60CBEA1DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift in Sources */,
+				F44F93F21DAEA8C900BC5B85 /* unittest_swift_performance.pb.swift in Sources */,
+				F44F93B41DAEA8C900BC5B85 /* Test_Api.swift in Sources */,
+				F44F93E41DAEA8C900BC5B85 /* unittest_no_generic_services.pb.swift in Sources */,
+				F44F944A1DBFF18100BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */,
+				DB2E0AFC1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */,
+				F44F93CF1DAEA8C900BC5B85 /* Test_Unknown_proto3.swift in Sources */,
+				F48FDD2A1E4D18080061D5C1 /* Test_TextFormat_proto3.swift in Sources */,
+				F44F93D61DAEA8C900BC5B85 /* unittest_import_lite.pb.swift in Sources */,
+				F44F93BE1DAEA8C900BC5B85 /* Test_JSON_Conformance.swift in Sources */,
+				F44F93E11DAEA8C900BC5B85 /* unittest_no_arena_lite.pb.swift in Sources */,
+				F48FDD291E4D18080061D5C1 /* Test_TextFormat_proto2_extensions.swift in Sources */,
+				F44F93CA1DAEA8C900BC5B85 /* Test_Reserved.swift in Sources */,
+				F44F93BF1DAEA8C900BC5B85 /* Test_JSON_Group.swift in Sources */,
+				F44F93E61DAEA8C900BC5B85 /* unittest_preserve_unknown_enum.pb.swift in Sources */,
+				F411FEAE1EDDDC62001AE6B2 /* Test_BinaryDecodingOptions.swift in Sources */,
+				F44F93E51DAEA8C900BC5B85 /* unittest_optimize_for.pb.swift in Sources */,
+				F44F943C1DBFBB7700BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */,
+				F44F93DB1DAEA8C900BC5B85 /* unittest_import.pb.swift in Sources */,
+				AA3640981E60EBB0000C3CF4 /* Test_Merge.swift in Sources */,
+				F45D73FF1EE9984C00E0A231 /* Test_MessageSet.swift in Sources */,
+				F44F93BC1DAEA8C900BC5B85 /* Test_FieldMask.swift in Sources */,
+				F4D3154C1DEC811C005D4A80 /* unittest_swift_extension3.pb.swift in Sources */,
+				F44F93D41DAEA8C900BC5B85 /* unittest_embed_optimize_for.pb.swift in Sources */,
+				F44F93C31DAEA8C900BC5B85 /* Test_Map.swift in Sources */,
+				F44F93F71DAEA8C900BC5B85 /* unittest_well_known_types.pb.swift in Sources */,
+				F44F93D01DAEA8C900BC5B85 /* Test_Wrappers.swift in Sources */,
+				F4584D3D1ECA4FC800803AB6 /* unittest_swift_oneof_merging.pb.swift in Sources */,
+				F4D315561DECA0EB005D4A80 /* unittest_swift_extension4.pb.swift in Sources */,
+				F44F93DA1DAEA8C900BC5B85 /* unittest_import_public.pb.swift in Sources */,
+				F4A07B2E1E4A3E640035678A /* test_messages_proto3.pb.swift in Sources */,
+				AA6CF6F71DB6D229007DF26B /* Test_Enum_Proto2.swift in Sources */,
+				F47C42B72437A3C700C08579 /* unittest_proto3_optional.pb.swift in Sources */,
+				F44F94371DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */,
+				F44F93C71DAEA8C900BC5B85 /* Test_ReallyLargeTagNumber.swift in Sources */,
+				F44F93C41DAEA8C900BC5B85 /* Test_Packed.swift in Sources */,
+				F47C42C42437A73000C08579 /* Test_AllTypes_Proto3_Optional.swift in Sources */,
+				F44F93B21DAEA8C900BC5B85 /* Test_AllTypes.swift in Sources */,
+				F44F93EA1DAEA8C900BC5B85 /* unittest_swift_all_required_types.pb.swift in Sources */,
+				F44F93B01DAEA8C900BC5B85 /* Message+UInt8ArrayHelpers.swift in Sources */,
+				F4D3154B1DEC811C005D4A80 /* unittest_swift_extension2.pb.swift in Sources */,
+				F44F93F41DAEA8C900BC5B85 /* unittest_swift_runtime_proto2.pb.swift in Sources */,
+				F44F93CE1DAEA8C900BC5B85 /* Test_Unknown_proto2.swift in Sources */,
+				F44F93AD1DAEA8C900BC5B85 /* TestHelpers.swift in Sources */,
+				F44F93F61DAEA8C900BC5B85 /* unittest_swift_startup.pb.swift in Sources */,
+				F44F93C51DAEA8C900BC5B85 /* Test_ParsingMerge.swift in Sources */,
+				9C7254681E5F9B1600486C98 /* Test_TextFormat_Unknown.swift in Sources */,
+				F44F93E91DAEA8C900BC5B85 /* unittest_proto3.pb.swift in Sources */,
+				F44F93D21DAEA8C900BC5B85 /* unittest_custom_options.pb.swift in Sources */,
+				F44F93B91DAEA8C900BC5B85 /* Test_Enum.swift in Sources */,
+				F44F93DE1DAEA8C900BC5B85 /* unittest_mset_wire_format.pb.swift in Sources */,
+				F44F93CB1DAEA8C900BC5B85 /* Test_Struct.swift in Sources */,
+				F44F944F1DBFF8DC00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */,
+				F44F93CC1DAEA8C900BC5B85 /* Test_Timestamp.swift in Sources */,
+				F4618B662154245600E5FABA /* Test_JSONEncodingOptions.swift in Sources */,
+				F44F93F31DAEA8C900BC5B85 /* unittest_swift_reserved.pb.swift in Sources */,
+				F482B67B1E856D2700A25EF8 /* unittest_swift_reserved_ext.pb.swift in Sources */,
+				F44F94401DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */,
+				F44F93F11DAEA8C900BC5B85 /* unittest_swift_naming.pb.swift in Sources */,
+				9CC8CAAE1EC512A0008EF45F /* generated_swift_names_enum_cases.pb.swift in Sources */,
+				F44F93F51DAEA8C900BC5B85 /* unittest_swift_runtime_proto3.pb.swift in Sources */,
+				F44F93ED1DAEA8C900BC5B85 /* unittest_swift_enum.pb.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F44F93F91DAEB13F00BC5B85 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0353A1D01E81625400067996 /* any.pb.swift in Sources */,
+				F44F94061DAEB23500BC5B85 /* api.pb.swift in Sources */,
+				F44F94071DAEB23500BC5B85 /* duration.pb.swift in Sources */,
+				F4618B592154151700E5FABA /* JSONEncodingOptions.swift in Sources */,
+				F44F94081DAEB23500BC5B85 /* empty.pb.swift in Sources */,
+				F44F94151DAEB23500BC5B85 /* Enum.swift in Sources */,
+				9C75F8921DDD3108005CCFF2 /* ExtensibleMessage.swift in Sources */,
+				AAE0F4E61E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift in Sources */,
+				F44F94171DAEB23500BC5B85 /* ExtensionFields.swift in Sources */,
+				9C75F88D1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */,
+				F47138991E4E56AC00C8492C /* Internal.swift in Sources */,
+				9C75F8881DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */,
+				F44F94191DAEB23500BC5B85 /* Decoder.swift in Sources */,
+				AAF2ED3D1DEF3FBC007B510F /* NameMap.swift in Sources */,
+				9CA424451E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
+				DB2E0B011EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */,
+				AA78AD391E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */,
+				AA05BF521DAEB7E800619042 /* FieldTag.swift in Sources */,
+				F411FE9E1EDDD707001AE6B2 /* JSONDecodingOptions.swift in Sources */,
+				F44F94221DAEB23500BC5B85 /* FieldTypes.swift in Sources */,
+				F44F94091DAEB23500BC5B85 /* field_mask.pb.swift in Sources */,
+				F4EDCC2E22DF896500A1ECB7 /* DoubleParser.swift in Sources */,
+				AA3640941E60D593000C3CF4 /* struct.pb.swift in Sources */,
+				F4E852B91EE9D84A00AE837E /* SelectiveVisitor.swift in Sources */,
+				F41BA4451E7B35C8004F6E95 /* AnyMessageStorage.swift in Sources */,
+				F44F940B1DAEB23500BC5B85 /* Google_Protobuf_Duration+Extensions.swift in Sources */,
+				F44F940C1DAEB23500BC5B85 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */,
+				ECBC5C4A1DF6ABC500F658E8 /* Google_Protobuf_Struct+Extensions.swift in Sources */,
+				F41BA3FF1E76F63A004F6E95 /* Google_Protobuf_Any+Registry.swift in Sources */,
+				F48769FB23020B7D00D44224 /* descriptor.pb.swift in Sources */,
+				ECBC5C4D1DF6ABC500F658E8 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */,
+				F4F4F1201E5C7565006C6CAD /* MathUtils.swift in Sources */,
+				9C84E4961E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */,
+				ECBC5C491DF6ABC500F658E8 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
+				E7038A27224D7F1000B68775 /* Data+Extensions.swift in Sources */,
+				F41BA4161E79BE56004F6E95 /* Google_Protobuf_Any+Extensions.swift in Sources */,
+				AA86F6FD1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */,
+				9C667A981E4C203D008B974F /* BinaryDecodingError.swift in Sources */,
+				F44F941A1DAEB23500BC5B85 /* HashVisitor.swift in Sources */,
+				F44F941C1DAEB23500BC5B85 /* JSONEncoder.swift in Sources */,
+				AAABA40E1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */,
+				F4151F741EFAB83A00EEA00B /* BinaryDelimited.swift in Sources */,
+				9C75F8A11DDD3FA3005CCFF2 /* JSONDecoder.swift in Sources */,
+				F411FEA21EDDD83E001AE6B2 /* BinaryDecodingOptions.swift in Sources */,
+				F44F941D1DAEB23500BC5B85 /* Message+JSONAdditions.swift in Sources */,
+				9C75F8A61DDD44A1005CCFF2 /* ProtobufMap.swift in Sources */,
+				F44F941E1DAEB23500BC5B85 /* Message.swift in Sources */,
+				F41BA41B1E79C59B004F6E95 /* AnyUnpackError.swift in Sources */,
+				F44F94181DAEB23500BC5B85 /* MessageExtension.swift in Sources */,
+				F44F94101DAEB23500BC5B85 /* BinaryDecoder.swift in Sources */,
+				F4539D2D1E6F5DD60076251F /* CustomJSONCodable.swift in Sources */,
+				F44F94111DAEB23500BC5B85 /* BinaryEncoder.swift in Sources */,
+				F44F94121DAEB23500BC5B85 /* BinaryEncodingSizeVisitor.swift in Sources */,
+				F4F4F11D1E5C7557006C6CAD /* TimeUtils.swift in Sources */,
+				F482B6B81E89941600A25EF8 /* Version.swift in Sources */,
+				9C75F8971DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift in Sources */,
+				F44F94131DAEB23500BC5B85 /* Message+BinaryAdditions.swift in Sources */,
+				AAF2ED421DEF4D94007B510F /* ProtoNameProviding.swift in Sources */,
+				ECBC5C501DF6ABC500F658E8 /* source_context.pb.swift in Sources */,
+				9C5890A81DFF6375001CFC34 /* TextFormatDecoder.swift in Sources */,
+				9C5890A91DFF6375001CFC34 /* TextFormatEncoder.swift in Sources */,
+				F48FDD261E4D17EF0061D5C1 /* JSONScanner.swift in Sources */,
+				F451074D23A288E400488257 /* UnsafeBufferPointer+Shims.swift in Sources */,
+				9C4178641E809DA2007830C3 /* ExtensionMap.swift in Sources */,
+				9C5890AA1DFF6375001CFC34 /* TextFormatEncodingVisitor.swift in Sources */,
+				9C84E4921E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
+				F451074923A288E400488257 /* UnsafeRawPointer+Shims.swift in Sources */,
+				9C5890AB1DFF6375001CFC34 /* TextFormatScanner.swift in Sources */,
+				9C0B366E1E5FAB910094E128 /* JSONMapEncodingVisitor.swift in Sources */,
+				9C5890AD1DFF6375001CFC34 /* Message+TextFormatAdditions.swift in Sources */,
+				ECBC5C4B1DF6ABC500F658E8 /* timestamp.pb.swift in Sources */,
+				ECBC5C4E1DF6ABC500F658E8 /* type.pb.swift in Sources */,
+				F44F94231DAEB23500BC5B85 /* UnknownStorage.swift in Sources */,
+				ECBC5C4C1DF6ABC500F658E8 /* Varint.swift in Sources */,
+				9C75F8831DDBE118005CCFF2 /* Visitor.swift in Sources */,
+				F49B576E2252771700350FFD /* TextFormatEncodingOptions.swift in Sources */,
+				AAB979F81E7066D8003DC2F4 /* Google_Protobuf_ListValue+Extensions.swift in Sources */,
+				AA05BF4D1DAEB7E400619042 /* WireFormat.swift in Sources */,
+				9C667A941E4C203D008B974F /* JSONDecodingError.swift in Sources */,
+				ECBC5C511DF6ABC500F658E8 /* wrappers.pb.swift in Sources */,
+				9C667A9C1E4C203D008B974F /* TextFormatDecodingError.swift in Sources */,
+				ECBC5C4F1DF6ABC500F658E8 /* ZigZag.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		9C8CDA191D7A288E00E207CA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BD12FD351D767BA0001815C7 /* SwiftProtobuf_iOS */;
+			targetProxy = 9C8CDA181D7A288E00E207CA /* PBXContainerItemProxy */;
+		};
+		F44F93A61DAEA7C500BC5B85 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F44F936E1DAEA53900BC5B85 /* SwiftProtobuf_tvOS */;
+			targetProxy = F44F93A51DAEA7C500BC5B85 /* PBXContainerItemProxy */;
+		};
+		__Dependency_Protobuf /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "______Target_Protobuf" /* SwiftProtobuf_macOS */;
+			targetProxy = 9CAEA5251D25B35600EB832A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		9C8CDA1B1D7A288E00E207CA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/ProtobufTestSuite_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobufTests;
+				PRODUCT_MODULE_NAME = SwiftProtobufTests;
+				PRODUCT_NAME = SwiftProtobufTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9C8CDA1C1D7A288E00E207CA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/ProtobufTestSuite_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobufTests;
+				PRODUCT_MODULE_NAME = SwiftProtobufTests;
+				PRODUCT_NAME = SwiftProtobufTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		BD12FD3B1D767BA1001815C7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/Protobuf_Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobuf;
+				PRODUCT_MODULE_NAME = SwiftProtobuf;
+				PRODUCT_NAME = SwiftProtobuf;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		BD12FD3C1D767BA1001815C7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/Protobuf_Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobuf;
+				PRODUCT_MODULE_NAME = SwiftProtobuf;
+				PRODUCT_NAME = SwiftProtobuf;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		F44F93741DAEA53900BC5B85 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/Protobuf_Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobuf;
+				PRODUCT_MODULE_NAME = SwiftProtobuf;
+				PRODUCT_NAME = SwiftProtobuf;
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		F44F93751DAEA53900BC5B85 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/Protobuf_Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobuf;
+				PRODUCT_MODULE_NAME = SwiftProtobuf;
+				PRODUCT_NAME = SwiftProtobuf;
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		F44F93A81DAEA7C500BC5B85 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/ProtobufTestSuite_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobufTests;
+				PRODUCT_MODULE_NAME = SwiftProtobufTests;
+				PRODUCT_NAME = SwiftProtobufTests;
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		F44F93A91DAEA7C500BC5B85 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/ProtobufTestSuite_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobufTests;
+				PRODUCT_MODULE_NAME = SwiftProtobufTests;
+				PRODUCT_NAME = SwiftProtobufTests;
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		F44F94031DAEB13F00BC5B85 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/Protobuf_Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobuf;
+				PRODUCT_MODULE_NAME = SwiftProtobuf;
+				PRODUCT_NAME = SwiftProtobuf;
+				SDKROOT = watchos;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		F44F94041DAEB13F00BC5B85 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/Protobuf_Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobuf;
+				PRODUCT_MODULE_NAME = SwiftProtobuf;
+				PRODUCT_NAME = SwiftProtobuf;
+				SDKROOT = watchos;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		_ReleaseConf_Protobuf /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/Protobuf_Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobuf;
+				PRODUCT_MODULE_NAME = SwiftProtobuf;
+				PRODUCT_NAME = SwiftProtobuf;
+			};
+			name = Release;
+		};
+		_ReleaseConf_ProtobufTestSuite /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/ProtobufTestSuite_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobufTests;
+				PRODUCT_MODULE_NAME = SwiftProtobufTests;
+				PRODUCT_NAME = SwiftProtobufTests;
+			};
+			name = Release;
+		};
+		"___DebugConf_Protobuf" /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/Protobuf_Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobuf;
+				PRODUCT_MODULE_NAME = SwiftProtobuf;
+				PRODUCT_NAME = SwiftProtobuf;
+			};
+			name = Debug;
+		};
+		"___DebugConf_ProtobufTestSuite" /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = SwiftProtobuf.xcodeproj/ProtobufTestSuite_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.protobuf.SwiftProtobufTests;
+				PRODUCT_MODULE_NAME = SwiftProtobufTests;
+				PRODUCT_NAME = SwiftProtobufTests;
+			};
+			name = Debug;
+		};
+		"_____Release_" /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1.8.0;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				SWIFT_VERSION = 5.0;
+				USE_HEADERMAP = NO;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		"_______Debug_" /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1.8.0;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				SWIFT_VERSION = 5.0;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9C8CDA1A1D7A288E00E207CA /* Build configuration list for PBXNativeTarget "SwiftProtobufTestSuite_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9C8CDA1B1D7A288E00E207CA /* Debug */,
+				9C8CDA1C1D7A288E00E207CA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BD12FD3D1D767BA1001815C7 /* Build configuration list for PBXNativeTarget "SwiftProtobuf_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BD12FD3B1D767BA1001815C7 /* Debug */,
+				BD12FD3C1D767BA1001815C7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F44F93761DAEA53900BC5B85 /* Build configuration list for PBXNativeTarget "SwiftProtobuf_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F44F93741DAEA53900BC5B85 /* Debug */,
+				F44F93751DAEA53900BC5B85 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F44F93A71DAEA7C500BC5B85 /* Build configuration list for PBXNativeTarget "SwiftProtobufTestSuite_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F44F93A81DAEA7C500BC5B85 /* Debug */,
+				F44F93A91DAEA7C500BC5B85 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F44F94051DAEB13F00BC5B85 /* Build configuration list for PBXNativeTarget "SwiftProtobuf_watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F44F94031DAEB13F00BC5B85 /* Debug */,
+				F44F94041DAEB13F00BC5B85 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		"___RootConfs_" /* Build configuration list for PBXProject "SwiftProtobuf" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				"_______Debug_" /* Debug */,
+				"_____Release_" /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		"_______Confs_Protobuf" /* Build configuration list for PBXNativeTarget "SwiftProtobuf_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				"___DebugConf_Protobuf" /* Debug */,
+				_ReleaseConf_Protobuf /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		"_______Confs_ProtobufTestSuite" /* Build configuration list for PBXNativeTarget "SwiftProtobufTestSuite_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				"___DebugConf_ProtobufTestSuite" /* Debug */,
+				_ReleaseConf_ProtobufTestSuite /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = __RootObject_ /* Project object */;
+}

--- a/spec/nanaimo/writer_spec.rb
+++ b/spec/nanaimo/writer_spec.rb
@@ -98,6 +98,14 @@ module Nanaimo
           expect(subject).to eq(%(#{utf8}"a'\\\"'\\\"b"\n))
         end
       end
+
+      describe 'string starts with three underscores' do
+        let(:root_object) { %(___a) }
+
+        it 'writes with quotes' do
+          expect(subject).to eq(%(#{utf8}"___a"\n))
+        end
+      end
     end
 
     describe Array do


### PR DESCRIPTION
It seems that for objects that start with at least 3 underscores, Xcode
wraps it with quotes. See this file for example:
https://github.com/apple/swift-protobuf/blob/master/SwiftProtobuf.xcodeproj/project.pbxproj

`PBXFileReference`s that start with 2 underscores aren't quoted, while
those that start with 4 are. I verified what Xcode with 3 underscores
manually.