### PR TITLE
Fix Ruby 2.7.0 warning

### DIFF
--- a/lib/nanaimo/writer.rb
+++ b/lib/nanaimo/writer.rb
@@ -27,7 +27,7 @@ module Nanaimo
     #
     UTF8 = "// !$*UTF8*$!\n".freeze
 
-    # @param plist [Plist,String,Hash,Array] The plist obejct to write
+    # @param plist [Plist,String,Hash,Array] The plist object to write
     # @param pretty [Boolean] Whether to serialize annotations and add
     #                         spaces and newlines to make output more legible
     # @param output [#<<] The output stream to write the plist to

--- a/lib/nanaimo/writer/pbxproj.rb
+++ b/lib/nanaimo/writer/pbxproj.rb
@@ -9,8 +9,8 @@ module Nanaimo
       ISA = String.new('isa', '')
       private_constant :ISA
 
-      def initialize(*)
-        super
+      def initialize(plist, **args)
+        super(plist, **args)
         @objects_section = false
       end
 


### PR DESCRIPTION
closes https://github.com/CocoaPods/Nanaimo/issues/49

When running CocoaPods with Ruby 2.7.0 a warning is emitted:

```
/Users/dimitris/Development/ios/Nanaimo/lib/nanaimo/writer/pbxproj.rb:13: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/dimitris/Development/ios/Nanaimo/lib/nanaimo/writer.rb:35: warning: The called method `initialize' is defined here
```

This fixes this warning.