### PR TITLE
Allow dollar signs in unquoted strings

### DIFF
--- a/lib/nanaimo/writer.rb
+++ b/lib/nanaimo/writer.rb
@@ -90,7 +90,7 @@ module Nanaimo
       output
     end
 
-    QUOTED_STRING_REGEXP = %r{\A\z|[^\w\./]|\A___}
+    QUOTED_STRING_REGEXP = %r{\A\z|[^\w\.\$/]|\A___}
     private_constant :QUOTED_STRING_REGEXP
 
     def write_string_quoted_if_necessary(object)

--- a/spec/nanaimo/writer_spec.rb
+++ b/spec/nanaimo/writer_spec.rb
@@ -80,6 +80,14 @@ module Nanaimo
           expect(subject).to eq("#{utf8}Value /*A whimsical value*/\n")
         end
       end
+
+      describe 'string with dollar sign' do
+        let(:root_object) { %($ABC) }
+
+        it 'writes without quotes' do
+          expect(subject).to eq(%(#{utf8}$ABC\n))
+        end
+      end
     end
 
     describe QuotedString do


### PR DESCRIPTION
From what I gathered, the true specification of the ASCII Plist format isn't available, so we have to end up guessing the spec according to what Xcode does?

In my testing, it looks like plist string values with `$` in them (in whatever position) are unquoted too. Here is an example pbxproj from a fresh new Xcode project on Xcode 12.5 (behavior confirmed on older Xcode versions as well): https://gist.github.com/arthuralee/8d89207f63bb3e5ba4c4758ede733904#file-project-pbxproj-L423-L424